### PR TITLE
feat: subscription auto-update and nodes list pagination

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -323,6 +323,9 @@ func main() {
 	notifyCtx, stopNotify := context.WithCancel(context.Background())
 	go handler.StartNotifyScheduler(notifyCtx, repo, trafficHandler)
 
+	autoUpdateCtx, stopAutoUpdate := context.WithCancel(context.Background())
+	go handler.StartExternalSubscriptionAutoUpdateScheduler(autoUpdateCtx, repo, subscribeDir)
+
 	go func() {
 		logger.Info("HTTP服务器启动", "version", version.Version, "address", addr)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -331,7 +334,7 @@ func main() {
 		}
 	}()
 
-	waitForShutdown(srv, stopCollector, stopProxySync, stopNotify)
+	waitForShutdown(srv, stopCollector, stopProxySync, stopNotify, stopAutoUpdate)
 }
 
 func getAddr() string {

--- a/internal/handler/external_subscriptions.go
+++ b/internal/handler/external_subscriptions.go
@@ -14,26 +14,91 @@ import (
 )
 
 type externalSubscriptionRequest struct {
-	Name        string `json:"name"`
-	URL         string `json:"url"`
-	UserAgent   string `json:"user_agent"`
-	TrafficMode string `json:"traffic_mode"` // 流量统计方式: "download", "upload", "both", "none"
+	Name                  string `json:"name"`
+	URL                   string `json:"url"`
+	UserAgent             string `json:"user_agent"`
+	TrafficMode           string `json:"traffic_mode"` // 流量统计方式: "download", "upload", "both", "none"
+	AutoUpdate            *bool  `json:"auto_update"` // 是否启用定时更新
+	UpdateIntervalMinutes *int   `json:"update_interval_minutes"` // 更新间隔（分钟）
 }
 
 type externalSubscriptionResponse struct {
-	ID          int64   `json:"id"`
-	Name        string  `json:"name"`
-	URL         string  `json:"url"`
-	UserAgent   string  `json:"user_agent"`
-	NodeCount   int     `json:"node_count"`
-	LastSyncAt  *string `json:"last_sync_at"`
-	Upload      int64   `json:"upload"`       // 已上传流量（字节）
-	Download    int64   `json:"download"`     // 已下载流量（字节）
-	Total       int64   `json:"total"`        // 总流量（字节）
-	Expire      *string `json:"expire"`       // 过期时间
-	TrafficMode string  `json:"traffic_mode"` // 流量统计方式: "download", "upload", "both", "none"
-	CreatedAt   string  `json:"created_at"`
-	UpdatedAt   string  `json:"updated_at"`
+	ID                    int64   `json:"id"`
+	Name                  string  `json:"name"`
+	URL                   string  `json:"url"`
+	UserAgent             string  `json:"user_agent"`
+	NodeCount             int     `json:"node_count"`
+	LastSyncAt            *string `json:"last_sync_at"`
+	Upload                int64   `json:"upload"`       // 已上传流量（字节）
+	Download              int64   `json:"download"`     // 已下载流量（字节）
+	Total                 int64   `json:"total"`        // 总流量（字节）
+	Expire                *string `json:"expire"`       // 过期时间
+	TrafficMode           string  `json:"traffic_mode"` // 流量统计方式: "download", "upload", "both", "none"
+	AutoUpdate            bool    `json:"auto_update"`
+	UpdateIntervalMinutes int     `json:"update_interval_minutes"`
+	CreatedAt             string  `json:"created_at"`
+	UpdatedAt             string  `json:"updated_at"`
+}
+
+
+func normalizeUpdateIntervalMinutes(minutes int) int {
+	if minutes < 0 {
+		return 0
+	}
+	// 最短 5 分钟，避免过于频繁
+	if minutes > 0 && minutes < 5 {
+		return 5
+	}
+	return minutes
+}
+
+func resolveAutoUpdateSettings(payload externalSubscriptionRequest, existingAuto bool, existingInterval int) (bool, int) {
+	autoUpdate := existingAuto
+	if payload.AutoUpdate != nil {
+		autoUpdate = *payload.AutoUpdate
+	}
+	interval := existingInterval
+	if payload.UpdateIntervalMinutes != nil {
+		interval = normalizeUpdateIntervalMinutes(*payload.UpdateIntervalMinutes)
+	}
+	if !autoUpdate {
+		// 关闭定时更新时保留间隔配置，便于再次开启
+		return false, interval
+	}
+	if interval <= 0 {
+		interval = 60 // 默认 1 小时
+	}
+	return true, interval
+}
+
+func toExternalSubscriptionResponse(sub storage.ExternalSubscription) externalSubscriptionResponse {
+	var lastSyncAt *string
+	if sub.LastSyncAt != nil {
+		formatted := sub.LastSyncAt.Format(time.RFC3339)
+		lastSyncAt = &formatted
+	}
+	var expire *string
+	if sub.Expire != nil {
+		formatted := sub.Expire.Format(time.RFC3339)
+		expire = &formatted
+	}
+	return externalSubscriptionResponse{
+		ID:                    sub.ID,
+		Name:                  sub.Name,
+		URL:                   sub.URL,
+		UserAgent:             sub.UserAgent,
+		NodeCount:             sub.NodeCount,
+		LastSyncAt:            lastSyncAt,
+		Upload:                sub.Upload,
+		Download:              sub.Download,
+		Total:                 sub.Total,
+		Expire:                expire,
+		TrafficMode:           sub.TrafficMode,
+		AutoUpdate:            sub.AutoUpdate,
+		UpdateIntervalMinutes: sub.UpdateIntervalMinutes,
+		CreatedAt:             sub.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:             sub.UpdatedAt.Format(time.RFC3339),
+	}
 }
 
 func NewExternalSubscriptionsHandler(repo *storage.TrafficRepository) http.Handler {
@@ -72,33 +137,7 @@ func handleListExternalSubscriptions(w http.ResponseWriter, r *http.Request, rep
 
 	resp := make([]externalSubscriptionResponse, 0, len(subs))
 	for _, sub := range subs {
-		var lastSyncAt *string
-		if sub.LastSyncAt != nil {
-			formatted := sub.LastSyncAt.Format(time.RFC3339)
-			lastSyncAt = &formatted
-		}
-
-		var expire *string
-		if sub.Expire != nil {
-			formatted := sub.Expire.Format(time.RFC3339)
-			expire = &formatted
-		}
-
-		resp = append(resp, externalSubscriptionResponse{
-			ID:          sub.ID,
-			Name:        sub.Name,
-			URL:         sub.URL,
-			UserAgent:   sub.UserAgent,
-			NodeCount:   sub.NodeCount,
-			LastSyncAt:  lastSyncAt,
-			Upload:      sub.Upload,
-			Download:    sub.Download,
-			Total:       sub.Total,
-			Expire:      expire,
-			TrafficMode: sub.TrafficMode,
-			CreatedAt:   sub.CreatedAt.Format(time.RFC3339),
-			UpdatedAt:   sub.UpdatedAt.Format(time.RFC3339),
-		})
+		resp = append(resp, toExternalSubscriptionResponse(sub))
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -183,25 +222,60 @@ func handleCreateExternalSubscription(w http.ResponseWriter, r *http.Request, re
 		}
 	}
 
+	autoUpdate, updateInterval := resolveAutoUpdateSettings(payload, false, 0)
+
 	now := time.Now()
 	sub := storage.ExternalSubscription{
-		Username:    username,
-		Name:        name,
-		URL:         url,
-		UserAgent:   payload.UserAgent,   // 会在存储层使用默认值如果为空
-		TrafficMode: payload.TrafficMode, // 会在存储层使用默认值如果为空
-		NodeCount:   0,
-		LastSyncAt:  &now,
-		Upload:      trafficUpload,
-		Download:    trafficDownload,
-		Total:       trafficTotal,
-		Expire:      trafficExpire,
+		Username:              username,
+		Name:                  name,
+		URL:                   url,
+		UserAgent:             payload.UserAgent,   // 会在存储层使用默认值如果为空
+		TrafficMode:           payload.TrafficMode, // 会在存储层使用默认值如果为空
+		NodeCount:             0,
+		LastSyncAt:            &now,
+		Upload:                trafficUpload,
+		Download:              trafficDownload,
+		Total:                 trafficTotal,
+		Expire:                trafficExpire,
+		AutoUpdate:            autoUpdate,
+		UpdateIntervalMinutes: updateInterval,
 	}
 
 	id, err := repo.CreateExternalSubscription(r.Context(), sub)
 	if err != nil {
 		if errors.Is(err, storage.ErrExternalSubscriptionExists) {
-			writeError(w, http.StatusConflict, errors.New("subscription with this URL already exists"))
+			// 已存在时更新 UA / 流量模式 / 定时更新设置，便于订阅导入再次配置
+			existing, getErr := repo.GetExternalSubscriptionByURL(r.Context(), username, url)
+			if getErr != nil {
+				writeError(w, http.StatusInternalServerError, getErr)
+				return
+			}
+			existing.Name = name
+			if strings.TrimSpace(payload.UserAgent) != "" {
+				existing.UserAgent = payload.UserAgent
+			}
+			if strings.TrimSpace(payload.TrafficMode) != "" {
+				existing.TrafficMode = payload.TrafficMode
+			}
+			existing.AutoUpdate, existing.UpdateIntervalMinutes = resolveAutoUpdateSettings(payload, existing.AutoUpdate, existing.UpdateIntervalMinutes)
+			if trafficTotal > 0 || trafficUpload > 0 || trafficDownload > 0 {
+				existing.Upload = trafficUpload
+				existing.Download = trafficDownload
+				existing.Total = trafficTotal
+				existing.Expire = trafficExpire
+			}
+			if err := repo.UpdateExternalSubscription(r.Context(), existing); err != nil {
+				writeError(w, http.StatusInternalServerError, err)
+				return
+			}
+			updated, getErr := repo.GetExternalSubscription(r.Context(), existing.ID, username)
+			if getErr != nil {
+				writeError(w, http.StatusInternalServerError, getErr)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(toExternalSubscriptionResponse(updated))
 			return
 		}
 		writeError(w, http.StatusInternalServerError, err)
@@ -214,37 +288,9 @@ func handleCreateExternalSubscription(w http.ResponseWriter, r *http.Request, re
 		return
 	}
 
-	var lastSyncAt *string
-	if created.LastSyncAt != nil {
-		formatted := created.LastSyncAt.Format(time.RFC3339)
-		lastSyncAt = &formatted
-	}
-
-	var expire *string
-	if created.Expire != nil {
-		formatted := created.Expire.Format(time.RFC3339)
-		expire = &formatted
-	}
-
-	resp := externalSubscriptionResponse{
-		ID:          created.ID,
-		Name:        created.Name,
-		URL:         created.URL,
-		UserAgent:   created.UserAgent,
-		NodeCount:   created.NodeCount,
-		LastSyncAt:  lastSyncAt,
-		Upload:      created.Upload,
-		Download:    created.Download,
-		Total:       created.Total,
-		Expire:      expire,
-		TrafficMode: created.TrafficMode,
-		CreatedAt:   created.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:   created.UpdatedAt.Format(time.RFC3339),
-	}
-
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(toExternalSubscriptionResponse(created))
 }
 
 func handleUpdateExternalSubscription(w http.ResponseWriter, r *http.Request, repo *storage.TrafficRepository, username string) {
@@ -294,19 +340,23 @@ func handleUpdateExternalSubscription(w http.ResponseWriter, r *http.Request, re
 		trafficMode = existing.TrafficMode
 	}
 
+	autoUpdate, updateInterval := resolveAutoUpdateSettings(payload, existing.AutoUpdate, existing.UpdateIntervalMinutes)
+
 	sub := storage.ExternalSubscription{
-		ID:          id,
-		Username:    username,
-		Name:        name,
-		URL:         url,
-		UserAgent:   payload.UserAgent, // 会在存储层使用默认值如果为空
-		TrafficMode: trafficMode,
-		NodeCount:   existing.NodeCount,
-		LastSyncAt:  existing.LastSyncAt,
-		Upload:      existing.Upload,
-		Download:    existing.Download,
-		Total:       existing.Total,
-		Expire:      existing.Expire,
+		ID:                    id,
+		Username:              username,
+		Name:                  name,
+		URL:                   url,
+		UserAgent:             payload.UserAgent, // 会在存储层使用默认值如果为空
+		TrafficMode:           trafficMode,
+		NodeCount:             existing.NodeCount,
+		LastSyncAt:            existing.LastSyncAt,
+		Upload:                existing.Upload,
+		Download:              existing.Download,
+		Total:                 existing.Total,
+		Expire:                existing.Expire,
+		AutoUpdate:            autoUpdate,
+		UpdateIntervalMinutes: updateInterval,
 	}
 
 	if err := repo.UpdateExternalSubscription(r.Context(), sub); err != nil {
@@ -324,37 +374,9 @@ func handleUpdateExternalSubscription(w http.ResponseWriter, r *http.Request, re
 		return
 	}
 
-	var lastSyncAt *string
-	if updated.LastSyncAt != nil {
-		formatted := updated.LastSyncAt.Format(time.RFC3339)
-		lastSyncAt = &formatted
-	}
-
-	var expire *string
-	if updated.Expire != nil {
-		formatted := updated.Expire.Format(time.RFC3339)
-		expire = &formatted
-	}
-
-	resp := externalSubscriptionResponse{
-		ID:          updated.ID,
-		Name:        updated.Name,
-		URL:         updated.URL,
-		UserAgent:   updated.UserAgent,
-		NodeCount:   updated.NodeCount,
-		LastSyncAt:  lastSyncAt,
-		Upload:      updated.Upload,
-		Download:    updated.Download,
-		Total:       updated.Total,
-		Expire:      expire,
-		TrafficMode: updated.TrafficMode,
-		CreatedAt:   updated.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:   updated.UpdatedAt.Format(time.RFC3339),
-	}
-
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(toExternalSubscriptionResponse(updated))
 }
 
 func handleDeleteExternalSubscription(w http.ResponseWriter, r *http.Request, repo *storage.TrafficRepository, username string) {

--- a/internal/handler/external_sync.go
+++ b/internal/handler/external_sync.go
@@ -1490,3 +1490,111 @@ func formatTrafficShort(bytes int64) string {
 	}
 	return fmt.Sprintf("%.0fMB", float64(bytes)/float64(mb))
 }
+
+
+// StartExternalSubscriptionAutoUpdateScheduler periodically syncs external subscriptions
+// that have AutoUpdate enabled, based on each subscription's UpdateIntervalMinutes.
+func StartExternalSubscriptionAutoUpdateScheduler(ctx context.Context, repo *storage.TrafficRepository, subscribeDir string) {
+	if repo == nil {
+		return
+	}
+
+	// 每分钟检查一次是否有到期的订阅
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	logger.Info("[外部订阅定时更新] 调度器已启动", "check_interval", "1分钟")
+
+	// 启动后稍等再跑第一轮，避免和启动其他任务抢资源
+	runExternalSubscriptionAutoUpdates(ctx, repo, subscribeDir)
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("[外部订阅定时更新] 调度器已停止")
+			return
+		case <-ticker.C:
+			runExternalSubscriptionAutoUpdates(ctx, repo, subscribeDir)
+		}
+	}
+}
+
+func runExternalSubscriptionAutoUpdates(ctx context.Context, repo *storage.TrafficRepository, subscribeDir string) {
+	if repo == nil {
+		return
+	}
+
+	// 独立超时，避免单次任务拖垮后续检查
+	runCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	subs, err := repo.ListAllExternalSubscriptions(runCtx)
+	if err != nil {
+		logger.Info("[外部订阅定时更新] 获取订阅列表失败", "error", err)
+		return
+	}
+
+	now := time.Now()
+	client := &http.Client{Timeout: 30 * time.Second}
+	settingsCache := make(map[string]storage.UserSettings)
+
+	synced := 0
+	for _, sub := range subs {
+		if !sub.AutoUpdate || sub.UpdateIntervalMinutes <= 0 {
+			continue
+		}
+
+		// 根据 last_sync_at 判断是否到期
+		if sub.LastSyncAt != nil {
+			elapsed := now.Sub(*sub.LastSyncAt)
+			if elapsed < time.Duration(sub.UpdateIntervalMinutes)*time.Minute {
+				continue
+			}
+		}
+
+		logger.Info("[外部订阅定时更新] 开始同步",
+			"user", sub.Username,
+			"name", sub.Name,
+			"interval_minutes", sub.UpdateIntervalMinutes)
+
+		userSettings, ok := settingsCache[sub.Username]
+		if !ok {
+			userSettings, err = repo.GetUserSettings(runCtx, sub.Username)
+			if err != nil {
+				logger.Info("[外部订阅定时更新] 获取用户设置失败，使用默认设置", "user", sub.Username, "error", err)
+				userSettings = storage.UserSettings{
+					MatchRule:      "node_name",
+					SyncScope:      "saved_only",
+					KeepNodeName:   true,
+					NodeNameFilter: defaultNodeNameFilterPattern,
+				}
+			}
+			settingsCache[sub.Username] = userSettings
+		}
+
+		nodeCount, updatedSub, err := syncSingleExternalSubscription(runCtx, client, repo, subscribeDir, sub.Username, sub, userSettings)
+		if err != nil {
+			logger.Info("[外部订阅定时更新] 同步失败", "user", sub.Username, "name", sub.Name, "error", err)
+			continue
+		}
+
+		syncTime := time.Now()
+		updatedSub.LastSyncAt = &syncTime
+		updatedSub.NodeCount = nodeCount
+		// 保留定时更新设置（sync 返回的 sub 已包含）
+		if err := repo.UpdateExternalSubscription(runCtx, updatedSub); err != nil {
+			logger.Info("[外部订阅定时更新] 更新同步时间失败", "user", sub.Username, "name", sub.Name, "error", err)
+			continue
+		}
+
+		synced++
+		logger.Info("[外部订阅定时更新] 同步完成",
+			"user", sub.Username,
+			"name", sub.Name,
+			"node_count", nodeCount)
+	}
+
+	if synced > 0 {
+		logger.Info("[外部订阅定时更新] 本轮完成", "synced", synced)
+	}
+}

--- a/internal/storage/traffic.go
+++ b/internal/storage/traffic.go
@@ -313,20 +313,22 @@ type SystemConfig struct {
 
 // ExternalSubscription represents an external subscription URL imported by user.
 type ExternalSubscription struct {
-	ID          int64
-	Username    string
-	Name        string
-	URL         string
-	UserAgent   string // User-Agent 请求头
-	NodeCount   int
-	LastSyncAt  *time.Time
-	Upload      int64      // 已上传流量（字节）
-	Download    int64      // 已下载流量（字节）
-	Total       int64      // 总流量（字节）
-	Expire      *time.Time // 过期时间
-	TrafficMode string     // 流量统计方式: "download", "upload", "both", "none"
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID                    int64
+	Username              string
+	Name                  string
+	URL                   string
+	UserAgent             string // User-Agent 请求头
+	NodeCount             int
+	LastSyncAt            *time.Time
+	Upload                int64      // 已上传流量（字节）
+	Download              int64      // 已下载流量（字节）
+	Total                 int64      // 总流量（字节）
+	Expire                *time.Time // 过期时间
+	TrafficMode           string     // 流量统计方式: "download", "upload", "both", "none"
+	AutoUpdate            bool       // 是否定时自动更新此订阅
+	UpdateIntervalMinutes int        // 定时更新间隔（分钟），>0 且 AutoUpdate 时生效
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
 }
 
 // OverrideScript represents a JavaScript override script.
@@ -844,6 +846,12 @@ CREATE INDEX IF NOT EXISTS idx_external_subscriptions_url ON external_subscripti
 		return err
 	}
 	if err := r.ensureExternalSubscriptionColumn("traffic_mode", "TEXT NOT NULL DEFAULT 'both'"); err != nil {
+		return err
+	}
+	if err := r.ensureExternalSubscriptionColumn("auto_update", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
+	}
+	if err := r.ensureExternalSubscriptionColumn("update_interval_minutes", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return err
 	}
 
@@ -3868,7 +3876,7 @@ func (r *TrafficRepository) ListExternalSubscriptions(ctx context.Context, usern
 		return nil, errors.New("username is required")
 	}
 
-	const stmt = `SELECT id, username, name, url, COALESCE(user_agent, 'clash-meta/2.4.0'), node_count, last_sync_at, COALESCE(upload, 0), COALESCE(download, 0), COALESCE(total, 0), expire, COALESCE(traffic_mode, 'both'), created_at, updated_at FROM external_subscriptions WHERE username = ? ORDER BY created_at DESC`
+	const stmt = `SELECT id, username, name, url, COALESCE(user_agent, 'clash-meta/2.4.0'), node_count, last_sync_at, COALESCE(upload, 0), COALESCE(download, 0), COALESCE(total, 0), expire, COALESCE(traffic_mode, 'both'), COALESCE(auto_update, 0), COALESCE(update_interval_minutes, 0), created_at, updated_at FROM external_subscriptions WHERE username = ? ORDER BY created_at DESC`
 	rows, err := r.db.QueryContext(ctx, stmt, username)
 	if err != nil {
 		return nil, fmt.Errorf("list external subscriptions: %w", err)
@@ -3879,9 +3887,11 @@ func (r *TrafficRepository) ListExternalSubscriptions(ctx context.Context, usern
 	for rows.Next() {
 		var sub ExternalSubscription
 		var lastSyncAt, expire sql.NullTime
-		if err := rows.Scan(&sub.ID, &sub.Username, &sub.Name, &sub.URL, &sub.UserAgent, &sub.NodeCount, &lastSyncAt, &sub.Upload, &sub.Download, &sub.Total, &expire, &sub.TrafficMode, &sub.CreatedAt, &sub.UpdatedAt); err != nil {
+		var autoUpdate int
+		if err := rows.Scan(&sub.ID, &sub.Username, &sub.Name, &sub.URL, &sub.UserAgent, &sub.NodeCount, &lastSyncAt, &sub.Upload, &sub.Download, &sub.Total, &expire, &sub.TrafficMode, &autoUpdate, &sub.UpdateIntervalMinutes, &sub.CreatedAt, &sub.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan external subscription: %w", err)
 		}
+		sub.AutoUpdate = autoUpdate != 0
 		if lastSyncAt.Valid {
 			sub.LastSyncAt = &lastSyncAt.Time
 		}
@@ -3914,15 +3924,17 @@ func (r *TrafficRepository) GetExternalSubscription(ctx context.Context, id int6
 		return sub, errors.New("username is required")
 	}
 
-	const stmt = `SELECT id, username, name, url, COALESCE(user_agent, 'clash-meta/2.4.0'), node_count, last_sync_at, COALESCE(upload, 0), COALESCE(download, 0), COALESCE(total, 0), expire, COALESCE(traffic_mode, 'both'), created_at, updated_at FROM external_subscriptions WHERE id = ? AND username = ? LIMIT 1`
+	const stmt = `SELECT id, username, name, url, COALESCE(user_agent, 'clash-meta/2.4.0'), node_count, last_sync_at, COALESCE(upload, 0), COALESCE(download, 0), COALESCE(total, 0), expire, COALESCE(traffic_mode, 'both'), COALESCE(auto_update, 0), COALESCE(update_interval_minutes, 0), created_at, updated_at FROM external_subscriptions WHERE id = ? AND username = ? LIMIT 1`
 	var lastSyncAt, expire sql.NullTime
-	err := r.db.QueryRowContext(ctx, stmt, id, username).Scan(&sub.ID, &sub.Username, &sub.Name, &sub.URL, &sub.UserAgent, &sub.NodeCount, &lastSyncAt, &sub.Upload, &sub.Download, &sub.Total, &expire, &sub.TrafficMode, &sub.CreatedAt, &sub.UpdatedAt)
+	var autoUpdate int
+	err := r.db.QueryRowContext(ctx, stmt, id, username).Scan(&sub.ID, &sub.Username, &sub.Name, &sub.URL, &sub.UserAgent, &sub.NodeCount, &lastSyncAt, &sub.Upload, &sub.Download, &sub.Total, &expire, &sub.TrafficMode, &autoUpdate, &sub.UpdateIntervalMinutes, &sub.CreatedAt, &sub.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return sub, ErrExternalSubscriptionNotFound
 		}
 		return sub, fmt.Errorf("get external subscription: %w", err)
 	}
+	sub.AutoUpdate = autoUpdate != 0
 
 	if lastSyncAt.Valid {
 		sub.LastSyncAt = &lastSyncAt.Time
@@ -3931,6 +3943,42 @@ func (r *TrafficRepository) GetExternalSubscription(ctx context.Context, id int6
 		sub.Expire = &expire.Time
 	}
 
+	return sub, nil
+}
+
+// GetExternalSubscriptionByURL retrieves an external subscription by username and URL.
+func (r *TrafficRepository) GetExternalSubscriptionByURL(ctx context.Context, username, url string) (ExternalSubscription, error) {
+	var sub ExternalSubscription
+	if r == nil || r.db == nil {
+		return sub, errors.New("traffic repository not initialized")
+	}
+
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return sub, errors.New("username is required")
+	}
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return sub, errors.New("subscription url is required")
+	}
+
+	const stmt = `SELECT id, username, name, url, COALESCE(user_agent, 'clash-meta/2.4.0'), node_count, last_sync_at, COALESCE(upload, 0), COALESCE(download, 0), COALESCE(total, 0), expire, COALESCE(traffic_mode, 'both'), COALESCE(auto_update, 0), COALESCE(update_interval_minutes, 0), created_at, updated_at FROM external_subscriptions WHERE username = ? AND url = ? LIMIT 1`
+	var lastSyncAt, expire sql.NullTime
+	var autoUpdate int
+	err := r.db.QueryRowContext(ctx, stmt, username, url).Scan(&sub.ID, &sub.Username, &sub.Name, &sub.URL, &sub.UserAgent, &sub.NodeCount, &lastSyncAt, &sub.Upload, &sub.Download, &sub.Total, &expire, &sub.TrafficMode, &autoUpdate, &sub.UpdateIntervalMinutes, &sub.CreatedAt, &sub.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return sub, ErrExternalSubscriptionNotFound
+		}
+		return sub, fmt.Errorf("get external subscription by url: %w", err)
+	}
+	sub.AutoUpdate = autoUpdate != 0
+	if lastSyncAt.Valid {
+		sub.LastSyncAt = &lastSyncAt.Time
+	}
+	if expire.Valid {
+		sub.Expire = &expire.Time
+	}
 	return sub, nil
 }
 
@@ -3965,8 +4013,17 @@ func (r *TrafficRepository) CreateExternalSubscription(ctx context.Context, sub 
 		trafficMode = "both"
 	}
 
-	const stmt = `INSERT INTO external_subscriptions (username, name, url, user_agent, node_count, last_sync_at, upload, download, total, expire, traffic_mode) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-	result, err := r.db.ExecContext(ctx, stmt, username, name, url, userAgent, sub.NodeCount, sub.LastSyncAt, sub.Upload, sub.Download, sub.Total, sub.Expire, trafficMode)
+	autoUpdate := 0
+	if sub.AutoUpdate {
+		autoUpdate = 1
+	}
+	updateInterval := sub.UpdateIntervalMinutes
+	if updateInterval < 0 {
+		updateInterval = 0
+	}
+
+	const stmt = `INSERT INTO external_subscriptions (username, name, url, user_agent, node_count, last_sync_at, upload, download, total, expire, traffic_mode, auto_update, update_interval_minutes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	result, err := r.db.ExecContext(ctx, stmt, username, name, url, userAgent, sub.NodeCount, sub.LastSyncAt, sub.Upload, sub.Download, sub.Total, sub.Expire, trafficMode, autoUpdate, updateInterval)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
 			return 0, ErrExternalSubscriptionExists
@@ -4017,8 +4074,17 @@ func (r *TrafficRepository) UpdateExternalSubscription(ctx context.Context, sub 
 		trafficMode = "both"
 	}
 
-	const stmt = `UPDATE external_subscriptions SET name = ?, url = ?, user_agent = ?, node_count = ?, last_sync_at = ?, upload = ?, download = ?, total = ?, expire = ?, traffic_mode = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND username = ?`
-	result, err := r.db.ExecContext(ctx, stmt, name, url, userAgent, sub.NodeCount, sub.LastSyncAt, sub.Upload, sub.Download, sub.Total, sub.Expire, trafficMode, sub.ID, username)
+	autoUpdate := 0
+	if sub.AutoUpdate {
+		autoUpdate = 1
+	}
+	updateInterval := sub.UpdateIntervalMinutes
+	if updateInterval < 0 {
+		updateInterval = 0
+	}
+
+	const stmt = `UPDATE external_subscriptions SET name = ?, url = ?, user_agent = ?, node_count = ?, last_sync_at = ?, upload = ?, download = ?, total = ?, expire = ?, traffic_mode = ?, auto_update = ?, update_interval_minutes = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND username = ?`
+	result, err := r.db.ExecContext(ctx, stmt, name, url, userAgent, sub.NodeCount, sub.LastSyncAt, sub.Upload, sub.Download, sub.Total, sub.Expire, trafficMode, autoUpdate, updateInterval, sub.ID, username)
 	if err != nil {
 		return fmt.Errorf("update external subscription: %w", err)
 	}
@@ -4365,7 +4431,7 @@ func (r *TrafficRepository) ListAllExternalSubscriptions(ctx context.Context) ([
 		return nil, errors.New("traffic repository not initialized")
 	}
 
-	const stmt = `SELECT id, username, name, url, COALESCE(user_agent, 'clash-meta/2.4.0'), node_count, last_sync_at, COALESCE(upload, 0), COALESCE(download, 0), COALESCE(total, 0), expire, COALESCE(traffic_mode, 'both'), created_at, updated_at FROM external_subscriptions ORDER BY created_at DESC`
+	const stmt = `SELECT id, username, name, url, COALESCE(user_agent, 'clash-meta/2.4.0'), node_count, last_sync_at, COALESCE(upload, 0), COALESCE(download, 0), COALESCE(total, 0), expire, COALESCE(traffic_mode, 'both'), COALESCE(auto_update, 0), COALESCE(update_interval_minutes, 0), created_at, updated_at FROM external_subscriptions ORDER BY created_at DESC`
 	rows, err := r.db.QueryContext(ctx, stmt)
 	if err != nil {
 		return nil, fmt.Errorf("list all external subscriptions: %w", err)
@@ -4377,9 +4443,11 @@ func (r *TrafficRepository) ListAllExternalSubscriptions(ctx context.Context) ([
 		var sub ExternalSubscription
 		var lastSyncAt sql.NullTime
 		var expire sql.NullTime
-		if err := rows.Scan(&sub.ID, &sub.Username, &sub.Name, &sub.URL, &sub.UserAgent, &sub.NodeCount, &lastSyncAt, &sub.Upload, &sub.Download, &sub.Total, &expire, &sub.TrafficMode, &sub.CreatedAt, &sub.UpdatedAt); err != nil {
+		var autoUpdate int
+		if err := rows.Scan(&sub.ID, &sub.Username, &sub.Name, &sub.URL, &sub.UserAgent, &sub.NodeCount, &lastSyncAt, &sub.Upload, &sub.Download, &sub.Total, &expire, &sub.TrafficMode, &autoUpdate, &sub.UpdateIntervalMinutes, &sub.CreatedAt, &sub.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan external subscription: %w", err)
 		}
+		sub.AutoUpdate = autoUpdate != 0
 		if lastSyncAt.Valid {
 			sub.LastSyncAt = &lastSyncAt.Time
 		}

--- a/miaomiaowu/src/routes/nodes.index.tsx
+++ b/miaomiaowu/src/routes/nodes.index.tsx
@@ -7,7 +7,7 @@ import { toast } from 'sonner'
 import { Topbar } from '@/components/layout/topbar'
 import { useAuthStore } from '@/stores/auth-store'
 import { api } from '@/lib/api'
-import { cn } from '@/lib/utils'
+import { cn, getPageNumbers } from '@/lib/utils'
 
 const CLASH_DRAFT_KEY_PREFIX = 'mmw_clash_config_draft_'
 import { Button } from '@/components/ui/button'
@@ -27,7 +27,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { type ProxyNode, type ClashProxy } from '@/lib/proxy-types'
 import { load as parseYAML, dump as dumpYAML } from 'js-yaml'
-import { Check, Pencil, X, Undo2, Activity, Eye, Copy, ChevronDown, Link2, Flag, GripVertical, Zap, Loader2, Expand, List, ArrowUpToLine, ArrowDownToLine, ArrowUp, ArrowDown, ArrowUpDown, Gauge } from 'lucide-react'
+import { Check, Pencil, X, Undo2, Activity, Eye, Copy, ChevronDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Link2, Flag, GripVertical, Zap, Loader2, Expand, List, ArrowUpToLine, ArrowDownToLine, ArrowUp, ArrowDown, ArrowUpDown, Gauge } from 'lucide-react'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import IpIcon from '@/assets/icons/ip.svg'
 import CaidanIcon from '@/assets/icons/125.svg'
@@ -380,6 +380,131 @@ const STORAGE_KEY_PROTOCOL = 'mmw_nodes_selectedProtocol'
 const STORAGE_KEY_TAG = 'mmw_nodes_tagFilter'
 const STORAGE_KEY_SELECTED_IDS = 'mmw_nodes_selectedIds'
 const STORAGE_KEY_RENDER_MODE = 'mmw_nodes_renderMode'
+const STORAGE_KEY_PAGE_SIZE = 'mmw_nodes_pageSize'
+const NODE_PAGE_SIZE_OPTIONS = [20, 50, 100, 200] as const
+
+function getStoredNodePageSize(): number {
+  try {
+    const raw = Number(localStorage.getItem(STORAGE_KEY_PAGE_SIZE))
+    if (NODE_PAGE_SIZE_OPTIONS.includes(raw as (typeof NODE_PAGE_SIZE_OPTIONS)[number])) {
+      return raw
+    }
+  } catch {
+    // ignore
+  }
+  return 50
+}
+
+// 节点列表分页条（顶部/底部复用）
+function NodeListPagination({
+  position,
+  total,
+  page,
+  pageSize,
+  totalPages,
+  onPageChange,
+  onPageSizeChange,
+}: {
+  position: 'top' | 'bottom'
+  total: number
+  page: number
+  pageSize: number
+  totalPages: number
+  onPageChange: (page: number) => void
+  onPageSizeChange: (size: number) => void
+}) {
+  if (total <= 0) return null
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between',
+        position === 'top' ? 'mb-4 border-b pb-4' : 'mt-4 border-t pt-4'
+      )}
+    >
+      <div className='flex flex-wrap items-center gap-2 text-sm text-muted-foreground'>
+        <span>每页</span>
+        <Select
+          value={String(pageSize)}
+          onValueChange={(v) => onPageSizeChange(Number(v))}
+        >
+          <SelectTrigger className='h-8 w-[96px]'>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {NODE_PAGE_SIZE_OPTIONS.map((size) => (
+              <SelectItem key={size} value={String(size)}>
+                {size}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <span>
+          共 {total} 个 · 第 {page}/{totalPages} 页
+        </span>
+      </div>
+      <div className='flex flex-wrap items-center gap-1'>
+        <Button
+          variant='outline'
+          size='icon'
+          className='h-8 w-8'
+          disabled={page <= 1}
+          onClick={() => onPageChange(1)}
+          title='第一页'
+        >
+          <ChevronsLeft className='h-4 w-4' />
+        </Button>
+        <Button
+          variant='outline'
+          size='icon'
+          className='h-8 w-8'
+          disabled={page <= 1}
+          onClick={() => onPageChange(Math.max(1, page - 1))}
+          title='上一页'
+        >
+          <ChevronLeft className='h-4 w-4' />
+        </Button>
+        {getPageNumbers(page, totalPages).map((item, idx) =>
+          item === '...' ? (
+            <span key={`ellipsis-${position}-${idx}`} className='px-1 text-muted-foreground'>
+              ...
+            </span>
+          ) : (
+            <Button
+              key={`${position}-${item}`}
+              variant={item === page ? 'default' : 'outline'}
+              size='sm'
+              className='h-8 min-w-8 px-2'
+              onClick={() => onPageChange(item as number)}
+            >
+              {item}
+            </Button>
+          )
+        )}
+        <Button
+          variant='outline'
+          size='icon'
+          className='h-8 w-8'
+          disabled={page >= totalPages}
+          onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+          title='下一页'
+        >
+          <ChevronRight className='h-4 w-4' />
+        </Button>
+        <Button
+          variant='outline'
+          size='icon'
+          className='h-8 w-8'
+          disabled={page >= totalPages}
+          onClick={() => onPageChange(totalPages)}
+          title='最后一页'
+        >
+          <ChevronsRight className='h-4 w-4' />
+        </Button>
+      </div>
+    </div>
+  )
+}
 
 // 从 localStorage 获取保存的筛选状态
 function getStoredFilterState() {
@@ -474,6 +599,10 @@ function NodesPage() {
   // 是否给导入节点强制写 skip-cert-verify（默认关，不污染节点原配置；不持久化）
   const [forceNodeSkipCert, setForceNodeSkipCert] = useState<boolean>(false)
 
+  // 订阅导入：定时自动更新
+  const [subscriptionAutoUpdate, setSubscriptionAutoUpdate] = useState(false)
+  const [subscriptionUpdateInterval, setSubscriptionUpdateInterval] = useState<number>(60)
+
   // 导入节点卡片折叠状态 - 默认折叠
   const [isInputCardExpanded, setIsInputCardExpanded] = useState(false)
 
@@ -483,6 +612,8 @@ function NodesPage() {
   // 虚拟滚动模式状态 - 从 localStorage 恢复，无缓存时先默认 virtual（后续根据节点数调整）
   const [renderMode, setRenderMode] = useState<RenderMode>(() => getStoredRenderMode() ?? 'virtual')
   const [renderModeInitialized, setRenderModeInitialized] = useState(() => getStoredRenderMode() !== null)
+  const [nodePage, setNodePage] = useState(1)
+  const [nodePageSize, setNodePageSize] = useState<number>(() => getStoredNodePageSize())
   const [sortMode, setSortMode] = useState(false)
   const nodeOrderSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const virtualListRef = useRef<HTMLDivElement>(null)
@@ -652,6 +783,13 @@ function NodesPage() {
       localStorage.setItem(STORAGE_KEY_RENDER_MODE, renderMode)
     } catch {}
   }, [renderMode])
+
+  // 保存每页条数到 localStorage
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY_PAGE_SIZE, String(nodePageSize))
+    } catch {}
+  }, [nodePageSize])
 
   useEffect(() => {
     try {
@@ -2005,7 +2143,14 @@ function NodesPage() {
 
   // 从订阅获取节点
   const fetchSubscriptionMutation = useMutation({
-    mutationFn: async ({ url, userAgent, fetchSkipCertVerify, forceNodeSkipCert }: { url: string; userAgent: string; fetchSkipCertVerify: boolean; forceNodeSkipCert: boolean }) => {
+    mutationFn: async ({ url, userAgent, fetchSkipCertVerify, forceNodeSkipCert }: {
+      url: string
+      userAgent: string
+      fetchSkipCertVerify: boolean
+      forceNodeSkipCert: boolean
+      autoUpdate: boolean
+      updateIntervalMinutes: number
+    }) => {
       const response = await api.post('/api/admin/nodes/fetch-subscription', {
         url,
         user_agent: userAgent,
@@ -2077,6 +2222,8 @@ function NodesPage() {
           name: finalTag,
           url: variables.url,
           user_agent: variables.userAgent, // 保存 User-Agent
+          auto_update: variables.autoUpdate,
+          update_interval_minutes: variables.updateIntervalMinutes,
         })
         // 刷新外部订阅列表和流量数据
         queryClient.invalidateQueries({ queryKey: ['external-subscriptions'] })
@@ -2387,6 +2534,8 @@ function NodesPage() {
       userAgent: finalUserAgent,
       fetchSkipCertVerify,
       forceNodeSkipCert,
+      autoUpdate: subscriptionAutoUpdate,
+      updateIntervalMinutes: subscriptionUpdateInterval,
     })
   }
 
@@ -2602,10 +2751,42 @@ function NodesPage() {
 
   const deferredFilteredNodes = useDeferredValue(filteredNodes)
 
+  // 筛选变化时回到第 1 页
+  useEffect(() => {
+    setNodePage(1)
+  }, [selectedProtocol, tagFilter, displayNodes.length])
+
+  const totalFilteredNodes = deferredFilteredNodes.length
+  const totalNodePages = Math.max(1, Math.ceil(totalFilteredNodes / nodePageSize) || 1)
+
+  useEffect(() => {
+    if (nodePage > totalNodePages) {
+      setNodePage(totalNodePages)
+    }
+  }, [nodePage, totalNodePages])
+
+  const paginatedNodes = useMemo(() => {
+    const start = (nodePage - 1) * nodePageSize
+    return deferredFilteredNodes.slice(start, start + nodePageSize)
+  }, [deferredFilteredNodes, nodePage, nodePageSize])
+
+  const pageRangeLabel = useMemo(() => {
+    if (totalFilteredNodes === 0) return '0'
+    const start = (nodePage - 1) * nodePageSize + 1
+    const end = Math.min(nodePage * nodePageSize, totalFilteredNodes)
+    return `${start}-${end}`
+  }, [nodePage, nodePageSize, totalFilteredNodes])
+
+  // 翻页时滚回列表顶部
+  useEffect(() => {
+    virtualListRef.current?.scrollTo?.({ top: 0 })
+    tableVirtualListRef.current?.scrollTo?.({ top: 0 })
+  }, [nodePage, nodePageSize])
+
   // 虚拟列表 - 移动端卡片视图
   const mobileVirtualEnabled = renderMode === 'virtual' && !isTablet
   const rowVirtualizer = useVirtualizer({
-    count: mobileVirtualEnabled ? deferredFilteredNodes.length : 0,
+    count: mobileVirtualEnabled ? paginatedNodes.length : 0,
     getScrollElement: () => virtualListRef.current,
     estimateSize: () => 180,
     overscan: 10,
@@ -2615,7 +2796,7 @@ function NodesPage() {
   // 虚拟列表 - 桌面端/平板端表格视图
   const tableVirtualEnabled = renderMode === 'virtual' && isTablet
   const tableVirtualizer = useVirtualizer({
-    count: tableVirtualEnabled ? deferredFilteredNodes.length : 0,
+    count: tableVirtualEnabled ? paginatedNodes.length : 0,
     getScrollElement: () => tableVirtualListRef.current,
     estimateSize: () => 56,
     overscan: 20,
@@ -2980,6 +3161,46 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                           为订阅导入的节点设置标签，留空将使用服务器地址作为标签
                         </p>
                       </div>
+                      <div className='space-y-2 rounded-md border p-3'>
+                        <div className='flex items-center justify-between gap-3'>
+                          <div className='space-y-1'>
+                            <Label htmlFor='subscription-auto-update' className='text-sm font-medium cursor-pointer'>
+                              定时更新此订阅
+                            </Label>
+                            <p className='text-xs text-muted-foreground'>
+                              开启后，服务端会按设定间隔自动拉取订阅并同步节点
+                            </p>
+                          </div>
+                          <Switch
+                            id='subscription-auto-update'
+                            checked={subscriptionAutoUpdate}
+                            onCheckedChange={setSubscriptionAutoUpdate}
+                          />
+                        </div>
+                        {subscriptionAutoUpdate && (
+                          <div className='flex flex-wrap items-center gap-2 pt-1'>
+                            <Label htmlFor='subscription-update-interval' className='text-sm whitespace-nowrap'>
+                              更新间隔
+                            </Label>
+                            <Select
+                              value={String(subscriptionUpdateInterval)}
+                              onValueChange={(v) => setSubscriptionUpdateInterval(Number(v))}
+                            >
+                              <SelectTrigger id='subscription-update-interval' className='w-[160px]'>
+                                <SelectValue placeholder='选择间隔' />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value='30'>30 分钟</SelectItem>
+                                <SelectItem value='60'>1 小时</SelectItem>
+                                <SelectItem value='180'>3 小时</SelectItem>
+                                <SelectItem value='360'>6 小时</SelectItem>
+                                <SelectItem value='720'>12 小时</SelectItem>
+                                <SelectItem value='1440'>24 小时</SelectItem>
+                              </SelectContent>
+                            </Select>
+                          </div>
+                        )}
+                      </div>
                       <div className='flex justify-end gap-2'>
                         <Button
                           onClick={handleFetchSubscription}
@@ -3007,7 +3228,14 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
               <CardHeader>
                 <div className='flex flex-col gap-4 md:flex-row md:items-center md:justify-between'>
                   <div>
-                    <CardTitle>节点列表 ({deferredFilteredNodes.length})</CardTitle>
+                    <CardTitle>
+                      节点列表 ({deferredFilteredNodes.length})
+                      {totalFilteredNodes > 0 && (
+                        <span className='ml-2 text-sm font-normal text-muted-foreground'>
+                          显示 {pageRangeLabel}
+                        </span>
+                      )}
+                    </CardTitle>
                     <p className='mt-2 text-sm font-semibold text-destructive'>注意!!! 节点的修改与删除均会同步更新所有订阅 </p>
                     <p className='mt-2 text-xs text-primary flex flex-wrap items-center gap-1'>
                       <Pencil className='h-4 w-4 inline' /> 编辑节点名称，
@@ -3354,6 +3582,19 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                     </div>
                   )}
 
+                  <NodeListPagination
+                    position='top'
+                    total={totalFilteredNodes}
+                    page={nodePage}
+                    pageSize={nodePageSize}
+                    totalPages={totalNodePages}
+                    onPageChange={setNodePage}
+                    onPageSizeChange={(size) => {
+                      setNodePageSize(size)
+                      setNodePage(1)
+                    }}
+                  />
+
                 {/* 移动端卡片视图 (<768px) */}
                 {!isTablet && renderMode === 'expanded' && (
                 <DndContext
@@ -3364,7 +3605,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                   onDragCancel={handleDragCancel}
                 >
                   <SortableContext
-                    items={deferredFilteredNodes.map(n => n.id)}
+                    items={paginatedNodes.map(n => n.id)}
                     strategy={verticalListSortingStrategy}
                   >
                     <div className='space-y-3'>
@@ -3375,7 +3616,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                           </CardContent>
                         </Card>
                       ) : (
-                        deferredFilteredNodes.map(node => (
+                        paginatedNodes.map(node => (
                           <SortableCard
                             key={node.id}
                             id={node.id}
@@ -3766,7 +4007,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                         }}
                       >
                         {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-                          const node = deferredFilteredNodes[virtualRow.index]
+                          const node = paginatedNodes[virtualRow.index]
                           if (!node) return null
                           return (
                             <div
@@ -4082,7 +4323,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                   {isTablet && !isDesktop && renderMode === 'expanded' && (
                   <div className='rounded-md border'>
                     <SortableContext
-                    items={deferredFilteredNodes.map(n => n.id)}
+                    items={paginatedNodes.map(n => n.id)}
                       strategy={verticalListSortingStrategy}
                     >
                     <Table className='w-full'>
@@ -4104,7 +4345,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                           </TableCell>
                         </TableRow>
                       ) : (
-                        deferredFilteredNodes.map(node => (
+                        paginatedNodes.map(node => (
                           <SortableTableRow
                             key={node.id}
                             id={node.id}
@@ -4573,7 +4814,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                             }}
                           >
                             {tableVirtualizer.getVirtualItems().map((virtualRow) => {
-                              const node = deferredFilteredNodes[virtualRow.index]
+                              const node = paginatedNodes[virtualRow.index]
                               if (!node) return null
                               return (
                                 <div
@@ -4804,7 +5045,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                   {isDesktop && renderMode === 'expanded' && (
                   <div className='rounded-md border'>
                     <SortableContext
-                      items={deferredFilteredNodes.map(n => n.id)}
+                      items={paginatedNodes.map(n => n.id)}
                       strategy={verticalListSortingStrategy}
                     >
                       <Table className='w-full'>
@@ -4827,7 +5068,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                               </TableCell>
                             </TableRow>
                           ) : (
-                            deferredFilteredNodes.map(node => (
+                            paginatedNodes.map(node => (
                           <SortableTableRow
                             key={node.id}
                             id={node.id}
@@ -5396,7 +5637,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                             }}
                           >
                             {tableVirtualizer.getVirtualItems().map((virtualRow) => {
-                              const node = deferredFilteredNodes[virtualRow.index]
+                              const node = paginatedNodes[virtualRow.index]
                               if (!node) return null
                               return (
                                 <div
@@ -5703,6 +5944,19 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                     document.body
                   )}
                 </DndContext>
+
+                  <NodeListPagination
+                    position='bottom'
+                    total={totalFilteredNodes}
+                    page={nodePage}
+                    pageSize={nodePageSize}
+                    totalPages={totalNodePages}
+                    onPageChange={setNodePage}
+                    onPageSizeChange={(size) => {
+                      setNodePageSize(size)
+                      setNodePage(1)
+                    }}
+                  />
                 </div>
               </CardContent>
             </Card>

--- a/miaomiaowu/src/routes/subscribe-files.index.tsx
+++ b/miaomiaowu/src/routes/subscribe-files.index.tsx
@@ -95,6 +95,8 @@ type ExternalSubscription = {
   total: number
   expire: string | null
   traffic_mode: 'download' | 'upload' | 'both' | 'none'
+  auto_update: boolean
+  update_interval_minutes: number
   created_at: string
   updated_at: string
 }
@@ -381,7 +383,9 @@ function SubscribeFilesPage() {
     name: '',
     url: '',
     user_agent: '',
-    traffic_mode: 'both' as 'download' | 'upload' | 'both' | 'none'
+    traffic_mode: 'both' as 'download' | 'upload' | 'both' | 'none',
+    auto_update: false,
+    update_interval_minutes: 60,
   })
 
   // 代理集合对话框状态
@@ -763,12 +767,22 @@ function SubscribeFilesPage() {
 
   // 更新外部订阅
   const updateExternalSubMutation = useMutation({
-    mutationFn: async (data: { id: number; name: string; url: string; user_agent: string; traffic_mode: string }) => {
+    mutationFn: async (data: {
+      id: number
+      name: string
+      url: string
+      user_agent: string
+      traffic_mode: string
+      auto_update?: boolean
+      update_interval_minutes?: number
+    }) => {
       await api.put(`/api/user/external-subscriptions?id=${data.id}`, {
         name: data.name,
         url: data.url,
         user_agent: data.user_agent,
-        traffic_mode: data.traffic_mode
+        traffic_mode: data.traffic_mode,
+        auto_update: data.auto_update,
+        update_interval_minutes: data.update_interval_minutes,
       })
     },
     onSuccess: () => {
@@ -4024,7 +4038,18 @@ function SubscribeFilesPage() {
                   columns={[
                     {
                       header: '名称',
-                      cell: (sub) => sub.name,
+                      cell: (sub) => (
+                        <div className='flex flex-col gap-1'>
+                          <span>{sub.name}</span>
+                          {sub.auto_update && (
+                            <Badge variant='secondary' className='w-fit text-[10px]'>
+                              定时 {sub.update_interval_minutes >= 60
+                                ? `${Math.round(sub.update_interval_minutes / 60)}h`
+                                : `${sub.update_interval_minutes}m`}
+                            </Badge>
+                          )}
+                        </div>
+                      ),
                       cellClassName: 'font-medium'
                     },
                     {
@@ -4242,7 +4267,9 @@ function SubscribeFilesPage() {
                                 name: sub.name,
                                 url: sub.url,
                                 user_agent: sub.user_agent,
-                                traffic_mode: sub.traffic_mode || 'both'
+                                traffic_mode: sub.traffic_mode || 'both',
+                                auto_update: Boolean(sub.auto_update),
+                                update_interval_minutes: sub.update_interval_minutes > 0 ? sub.update_interval_minutes : 60,
                               })
                               setEditExternalSubDialogOpen(true)
                             }}
@@ -4316,6 +4343,13 @@ function SubscribeFilesPage() {
                             </TooltipContent>
                           </Tooltip>
                           <div className='font-medium text-sm truncate'>{sub.name}</div>
+                          {sub.auto_update && (
+                            <div className='text-[10px] text-muted-foreground'>
+                              定时更新 · {sub.update_interval_minutes >= 60
+                                ? `${Math.round(sub.update_interval_minutes / 60)} 小时`
+                                : `${sub.update_interval_minutes} 分钟`}
+                            </div>
+                          )}
                         </div>
                         <div className='flex items-center gap-1'>
                           <Button
@@ -4329,7 +4363,9 @@ function SubscribeFilesPage() {
                                 name: sub.name,
                                 url: sub.url,
                                 user_agent: sub.user_agent,
-                                traffic_mode: sub.traffic_mode || 'both'
+                                traffic_mode: sub.traffic_mode || 'both',
+                                auto_update: Boolean(sub.auto_update),
+                                update_interval_minutes: sub.update_interval_minutes > 0 ? sub.update_interval_minutes : 60,
                               })
                               setEditExternalSubDialogOpen(true)
                             }}
@@ -6385,6 +6421,46 @@ function SubscribeFilesPage() {
                 选择如何计算已用流量：上下行为两者相加，仅下行或仅上行则只计算对应流量
               </p>
             </div>
+            <div className='space-y-2 rounded-md border p-3'>
+              <div className='flex items-center justify-between gap-3'>
+                <div className='space-y-1'>
+                  <Label htmlFor='edit-sub-auto-update' className='text-sm font-medium cursor-pointer'>
+                    定时更新此订阅
+                  </Label>
+                  <p className='text-xs text-muted-foreground'>
+                    开启后服务端按间隔自动拉取并同步节点
+                  </p>
+                </div>
+                <Switch
+                  id='edit-sub-auto-update'
+                  checked={editExternalSubForm.auto_update}
+                  onCheckedChange={(checked) => setEditExternalSubForm(prev => ({ ...prev, auto_update: checked }))}
+                />
+              </div>
+              {editExternalSubForm.auto_update && (
+                <div className='flex flex-wrap items-center gap-2 pt-1'>
+                  <Label htmlFor='edit-sub-update-interval' className='text-sm whitespace-nowrap'>
+                    更新间隔
+                  </Label>
+                  <Select
+                    value={String(editExternalSubForm.update_interval_minutes)}
+                    onValueChange={(v) => setEditExternalSubForm(prev => ({ ...prev, update_interval_minutes: Number(v) }))}
+                  >
+                    <SelectTrigger id='edit-sub-update-interval' className='w-[160px]'>
+                      <SelectValue placeholder='选择间隔' />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value='30'>30 分钟</SelectItem>
+                      <SelectItem value='60'>1 小时</SelectItem>
+                      <SelectItem value='180'>3 小时</SelectItem>
+                      <SelectItem value='360'>6 小时</SelectItem>
+                      <SelectItem value='720'>12 小时</SelectItem>
+                      <SelectItem value='1440'>24 小时</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+            </div>
           </div>
           <DialogFooter>
             <Button variant='outline' onClick={() => setEditExternalSubDialogOpen(false)}>
@@ -6398,7 +6474,9 @@ function SubscribeFilesPage() {
                     name: editingExternalSub.name,
                     url: editExternalSubForm.url,
                     user_agent: editingExternalSub.user_agent,
-                    traffic_mode: editExternalSubForm.traffic_mode
+                    traffic_mode: editExternalSubForm.traffic_mode,
+                    auto_update: editExternalSubForm.auto_update,
+                    update_interval_minutes: editExternalSubForm.update_interval_minutes,
                   })
                   setEditExternalSubDialogOpen(false)
                   setEditingExternalSub(null)


### PR DESCRIPTION
## Summary
- Add per-subscription scheduled auto-update on import/edit (interval options + persistence)
- Backend scheduler periodically syncs due external subscriptions
- Add dual top/bottom pagination for the nodes management list

## Test plan
- [ ] Import a subscription with auto-update enabled and verify interval is saved
- [ ] Confirm due subscriptions refresh without manual sync
- [ ] Edit an external subscription auto-update settings on subscribe-files page
- [ ] On `/nodes`, verify top and bottom pagination change the list correctly
- [ ] Change page size and confirm it persists after reload