### PR TITLE
feat: auto-update, pagination, aggregate subs, generator perf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,11 +135,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Normalize image name
+        run: |
+          echo "IMAGE_NAME=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,0 +1,121 @@
+name: Docker GHCR
+
+on:
+  push:
+    branches:
+      - main
+      - "codex/**"
+    tags:
+      - "v*"
+    paths-ignore:
+      - "**/*.md"
+      - ".gitignore"
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: "Target platforms"
+        required: true
+        default: "linux/amd64"
+        type: choice
+        options:
+          - linux/amd64
+          - linux/amd64,linux/arm64
+
+concurrency:
+  group: docker-ghcr-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set image name (lowercase required by GHCR)
+        run: |
+          OWNER_REPO="${{ github.repository }}"
+          IMAGE_NAME="${REGISTRY}/$(echo "${OWNER_REPO}" | tr '[:upper:]' '[:lower:]')"
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> "$GITHUB_ENV"
+          echo "Image: ${IMAGE_NAME}"
+
+      - name: Set platforms
+        id: platforms
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PLATFORMS="${{ inputs.platforms }}"
+          elif [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            PLATFORMS="linux/amd64,linux/arm64"
+          else
+            PLATFORMS="linux/amd64"
+          fi
+          echo "value=${PLATFORMS}" >> "$GITHUB_OUTPUT"
+          echo "Platforms: ${PLATFORMS}"
+
+      - name: Set up QEMU
+        if: contains(steps.platforms.outputs.value, 'arm64')
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ steps.platforms.outputs.value }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+
+      - name: Summary
+        run: |
+          {
+            echo "## Docker image pushed"
+            echo ""
+            echo "**Registry:** \`${{ env.IMAGE_NAME }}\`"
+            echo ""
+            echo "**Tags:**"
+            echo '```'
+            echo "${{ steps.meta.outputs.tags }}"
+            echo '```'
+            echo ""
+            echo "### Pull example"
+            echo '```bash'
+            echo "docker pull ${{ env.IMAGE_NAME }}:sha-${GITHUB_SHA:0:7}"
+            echo "docker pull ${{ env.IMAGE_NAME }}:${{ github.ref_name }}"
+            echo '```'
+            echo ""
+            echo "> First push packages are private by default. Make it public under GitHub Packages if needed."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -323,6 +323,9 @@ func main() {
 	notifyCtx, stopNotify := context.WithCancel(context.Background())
 	go handler.StartNotifyScheduler(notifyCtx, repo, trafficHandler)
 
+	autoUpdateCtx, stopAutoUpdate := context.WithCancel(context.Background())
+	go handler.StartExternalSubscriptionAutoUpdateScheduler(autoUpdateCtx, repo, subscribeDir)
+
 	go func() {
 		logger.Info("HTTP服务器启动", "version", version.Version, "address", addr)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -331,7 +334,7 @@ func main() {
 		}
 	}()
 
-	waitForShutdown(srv, stopCollector, stopProxySync, stopNotify)
+	waitForShutdown(srv, stopCollector, stopProxySync, stopNotify, stopAutoUpdate)
 }
 
 func getAddr() string {

--- a/internal/handler/external_subscriptions.go
+++ b/internal/handler/external_subscriptions.go
@@ -14,26 +14,91 @@ import (
 )
 
 type externalSubscriptionRequest struct {
-	Name        string `json:"name"`
-	URL         string `json:"url"`
-	UserAgent   string `json:"user_agent"`
-	TrafficMode string `json:"traffic_mode"` // 流量统计方式: "download", "upload", "both", "none"
+	Name                  string `json:"name"`
+	URL                   string `json:"url"`
+	UserAgent             string `json:"user_agent"`
+	TrafficMode           string `json:"traffic_mode"` // 流量统计方式: "download", "upload", "both", "none"
+	AutoUpdate            *bool  `json:"auto_update"` // 是否启用定时更新
+	UpdateIntervalMinutes *int   `json:"update_interval_minutes"` // 更新间隔（分钟）
 }
 
 type externalSubscriptionResponse struct {
-	ID          int64   `json:"id"`
-	Name        string  `json:"name"`
-	URL         string  `json:"url"`
-	UserAgent   string  `json:"user_agent"`
-	NodeCount   int     `json:"node_count"`
-	LastSyncAt  *string `json:"last_sync_at"`
-	Upload      int64   `json:"upload"`       // 已上传流量（字节）
-	Download    int64   `json:"download"`     // 已下载流量（字节）
-	Total       int64   `json:"total"`        // 总流量（字节）
-	Expire      *string `json:"expire"`       // 过期时间
-	TrafficMode string  `json:"traffic_mode"` // 流量统计方式: "download", "upload", "both", "none"
-	CreatedAt   string  `json:"created_at"`
-	UpdatedAt   string  `json:"updated_at"`
+	ID                    int64   `json:"id"`
+	Name                  string  `json:"name"`
+	URL                   string  `json:"url"`
+	UserAgent             string  `json:"user_agent"`
+	NodeCount             int     `json:"node_count"`
+	LastSyncAt            *string `json:"last_sync_at"`
+	Upload                int64   `json:"upload"`       // 已上传流量（字节）
+	Download              int64   `json:"download"`     // 已下载流量（字节）
+	Total                 int64   `json:"total"`        // 总流量（字节）
+	Expire                *string `json:"expire"`       // 过期时间
+	TrafficMode           string  `json:"traffic_mode"` // 流量统计方式: "download", "upload", "both", "none"
+	AutoUpdate            bool    `json:"auto_update"`
+	UpdateIntervalMinutes int     `json:"update_interval_minutes"`
+	CreatedAt             string  `json:"created_at"`
+	UpdatedAt             string  `json:"updated_at"`
+}
+
+
+func normalizeUpdateIntervalMinutes(minutes int) int {
+	if minutes < 0 {
+		return 0
+	}
+	// 最短 5 分钟，避免过于频繁
+	if minutes > 0 && minutes < 5 {
+		return 5
+	}
+	return minutes
+}
+
+func resolveAutoUpdateSettings(payload externalSubscriptionRequest, existingAuto bool, existingInterval int) (bool, int) {
+	autoUpdate := existingAuto
+	if payload.AutoUpdate != nil {
+		autoUpdate = *payload.AutoUpdate
+	}
+	interval := existingInterval
+	if payload.UpdateIntervalMinutes != nil {
+		interval = normalizeUpdateIntervalMinutes(*payload.UpdateIntervalMinutes)
+	}
+	if !autoUpdate {
+		// 关闭定时更新时保留间隔配置，便于再次开启
+		return false, interval
+	}
+	if interval <= 0 {
+		interval = 60 // 默认 1 小时
+	}
+	return true, interval
+}
+
+func toExternalSubscriptionResponse(sub storage.ExternalSubscription) externalSubscriptionResponse {
+	var lastSyncAt *string
+	if sub.LastSyncAt != nil {
+		formatted := sub.LastSyncAt.Format(time.RFC3339)
+		lastSyncAt = &formatted
+	}
+	var expire *string
+	if sub.Expire != nil {
+		formatted := sub.Expire.Format(time.RFC3339)
+		expire = &formatted
+	}
+	return externalSubscriptionResponse{
+		ID:                    sub.ID,
+		Name:                  sub.Name,
+		URL:                   sub.URL,
+		UserAgent:             sub.UserAgent,
+		NodeCount:             sub.NodeCount,
+		LastSyncAt:            lastSyncAt,
+		Upload:                sub.Upload,
+		Download:              sub.Download,
+		Total:                 sub.Total,
+		Expire:                expire,
+		TrafficMode:           sub.TrafficMode,
+		AutoUpdate:            sub.AutoUpdate,
+		UpdateIntervalMinutes: sub.UpdateIntervalMinutes,
+		CreatedAt:             sub.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:             sub.UpdatedAt.Format(time.RFC3339),
+	}
 }
 
 func NewExternalSubscriptionsHandler(repo *storage.TrafficRepository) http.Handler {
@@ -72,33 +137,7 @@ func handleListExternalSubscriptions(w http.ResponseWriter, r *http.Request, rep
 
 	resp := make([]externalSubscriptionResponse, 0, len(subs))
 	for _, sub := range subs {
-		var lastSyncAt *string
-		if sub.LastSyncAt != nil {
-			formatted := sub.LastSyncAt.Format(time.RFC3339)
-			lastSyncAt = &formatted
-		}
-
-		var expire *string
-		if sub.Expire != nil {
-			formatted := sub.Expire.Format(time.RFC3339)
-			expire = &formatted
-		}
-
-		resp = append(resp, externalSubscriptionResponse{
-			ID:          sub.ID,
-			Name:        sub.Name,
-			URL:         sub.URL,
-			UserAgent:   sub.UserAgent,
-			NodeCount:   sub.NodeCount,
-			LastSyncAt:  lastSyncAt,
-			Upload:      sub.Upload,
-			Download:    sub.Download,
-			Total:       sub.Total,
-			Expire:      expire,
-			TrafficMode: sub.TrafficMode,
-			CreatedAt:   sub.CreatedAt.Format(time.RFC3339),
-			UpdatedAt:   sub.UpdatedAt.Format(time.RFC3339),
-		})
+		resp = append(resp, toExternalSubscriptionResponse(sub))
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -183,25 +222,60 @@ func handleCreateExternalSubscription(w http.ResponseWriter, r *http.Request, re
 		}
 	}
 
+	autoUpdate, updateInterval := resolveAutoUpdateSettings(payload, false, 0)
+
 	now := time.Now()
 	sub := storage.ExternalSubscription{
-		Username:    username,
-		Name:        name,
-		URL:         url,
-		UserAgent:   payload.UserAgent,   // 会在存储层使用默认值如果为空
-		TrafficMode: payload.TrafficMode, // 会在存储层使用默认值如果为空
-		NodeCount:   0,
-		LastSyncAt:  &now,
-		Upload:      trafficUpload,
-		Download:    trafficDownload,
-		Total:       trafficTotal,
-		Expire:      trafficExpire,
+		Username:              username,
+		Name:                  name,
+		URL:                   url,
+		UserAgent:             payload.UserAgent,   // 会在存储层使用默认值如果为空
+		TrafficMode:           payload.TrafficMode, // 会在存储层使用默认值如果为空
+		NodeCount:             0,
+		LastSyncAt:            &now,
+		Upload:                trafficUpload,
+		Download:              trafficDownload,
+		Total:                 trafficTotal,
+		Expire:                trafficExpire,
+		AutoUpdate:            autoUpdate,
+		UpdateIntervalMinutes: updateInterval,
 	}
 
 	id, err := repo.CreateExternalSubscription(r.Context(), sub)
 	if err != nil {
 		if errors.Is(err, storage.ErrExternalSubscriptionExists) {
-			writeError(w, http.StatusConflict, errors.New("subscription with this URL already exists"))
+			// 已存在时更新 UA / 流量模式 / 定时更新设置，便于订阅导入再次配置
+			existing, getErr := repo.GetExternalSubscriptionByURL(r.Context(), username, url)
+			if getErr != nil {
+				writeError(w, http.StatusInternalServerError, getErr)
+				return
+			}
+			existing.Name = name
+			if strings.TrimSpace(payload.UserAgent) != "" {
+				existing.UserAgent = payload.UserAgent
+			}
+			if strings.TrimSpace(payload.TrafficMode) != "" {
+				existing.TrafficMode = payload.TrafficMode
+			}
+			existing.AutoUpdate, existing.UpdateIntervalMinutes = resolveAutoUpdateSettings(payload, existing.AutoUpdate, existing.UpdateIntervalMinutes)
+			if trafficTotal > 0 || trafficUpload > 0 || trafficDownload > 0 {
+				existing.Upload = trafficUpload
+				existing.Download = trafficDownload
+				existing.Total = trafficTotal
+				existing.Expire = trafficExpire
+			}
+			if err := repo.UpdateExternalSubscription(r.Context(), existing); err != nil {
+				writeError(w, http.StatusInternalServerError, err)
+				return
+			}
+			updated, getErr := repo.GetExternalSubscription(r.Context(), existing.ID, username)
+			if getErr != nil {
+				writeError(w, http.StatusInternalServerError, getErr)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(toExternalSubscriptionResponse(updated))
 			return
 		}
 		writeError(w, http.StatusInternalServerError, err)
@@ -214,37 +288,9 @@ func handleCreateExternalSubscription(w http.ResponseWriter, r *http.Request, re
 		return
 	}
 
-	var lastSyncAt *string
-	if created.LastSyncAt != nil {
-		formatted := created.LastSyncAt.Format(time.RFC3339)
-		lastSyncAt = &formatted
-	}
-
-	var expire *string
-	if created.Expire != nil {
-		formatted := created.Expire.Format(time.RFC3339)
-		expire = &formatted
-	}
-
-	resp := externalSubscriptionResponse{
-		ID:          created.ID,
-		Name:        created.Name,
-		URL:         created.URL,
-		UserAgent:   created.UserAgent,
-		NodeCount:   created.NodeCount,
-		LastSyncAt:  lastSyncAt,
-		Upload:      created.Upload,
-		Download:    created.Download,
-		Total:       created.Total,
-		Expire:      expire,
-		TrafficMode: created.TrafficMode,
-		CreatedAt:   created.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:   created.UpdatedAt.Format(time.RFC3339),
-	}
-
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(toExternalSubscriptionResponse(created))
 }
 
 func handleUpdateExternalSubscription(w http.ResponseWriter, r *http.Request, repo *storage.TrafficRepository, username string) {
@@ -294,19 +340,23 @@ func handleUpdateExternalSubscription(w http.ResponseWriter, r *http.Request, re
 		trafficMode = existing.TrafficMode
 	}
 
+	autoUpdate, updateInterval := resolveAutoUpdateSettings(payload, existing.AutoUpdate, existing.UpdateIntervalMinutes)
+
 	sub := storage.ExternalSubscription{
-		ID:          id,
-		Username:    username,
-		Name:        name,
-		URL:         url,
-		UserAgent:   payload.UserAgent, // 会在存储层使用默认值如果为空
-		TrafficMode: trafficMode,
-		NodeCount:   existing.NodeCount,
-		LastSyncAt:  existing.LastSyncAt,
-		Upload:      existing.Upload,
-		Download:    existing.Download,
-		Total:       existing.Total,
-		Expire:      existing.Expire,
+		ID:                    id,
+		Username:              username,
+		Name:                  name,
+		URL:                   url,
+		UserAgent:             payload.UserAgent, // 会在存储层使用默认值如果为空
+		TrafficMode:           trafficMode,
+		NodeCount:             existing.NodeCount,
+		LastSyncAt:            existing.LastSyncAt,
+		Upload:                existing.Upload,
+		Download:              existing.Download,
+		Total:                 existing.Total,
+		Expire:                existing.Expire,
+		AutoUpdate:            autoUpdate,
+		UpdateIntervalMinutes: updateInterval,
 	}
 
 	if err := repo.UpdateExternalSubscription(r.Context(), sub); err != nil {
@@ -324,37 +374,9 @@ func handleUpdateExternalSubscription(w http.ResponseWriter, r *http.Request, re
 		return
 	}
 
-	var lastSyncAt *string
-	if updated.LastSyncAt != nil {
-		formatted := updated.LastSyncAt.Format(time.RFC3339)
-		lastSyncAt = &formatted
-	}
-
-	var expire *string
-	if updated.Expire != nil {
-		formatted := updated.Expire.Format(time.RFC3339)
-		expire = &formatted
-	}
-
-	resp := externalSubscriptionResponse{
-		ID:          updated.ID,
-		Name:        updated.Name,
-		URL:         updated.URL,
-		UserAgent:   updated.UserAgent,
-		NodeCount:   updated.NodeCount,
-		LastSyncAt:  lastSyncAt,
-		Upload:      updated.Upload,
-		Download:    updated.Download,
-		Total:       updated.Total,
-		Expire:      expire,
-		TrafficMode: updated.TrafficMode,
-		CreatedAt:   updated.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:   updated.UpdatedAt.Format(time.RFC3339),
-	}
-
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(toExternalSubscriptionResponse(updated))
 }
 
 func handleDeleteExternalSubscription(w http.ResponseWriter, r *http.Request, repo *storage.TrafficRepository, username string) {

--- a/internal/handler/external_sync.go
+++ b/internal/handler/external_sync.go
@@ -514,6 +514,7 @@ func syncSingleExternalSubscription(ctx context.Context, client *http.Client, re
 	updatedCount := 0
 	createdCount := 0
 	skippedCount := 0
+	touchedNodeIDs := make(map[int64]bool)
 
 	for _, node := range nodesToUpdate {
 		var existingNode *storage.Node
@@ -608,6 +609,7 @@ func syncSingleExternalSubscription(ctx context.Context, client *http.Client, re
 			existingNode.ClashConfig = node.ClashConfig
 			existingNode.Enabled = node.Enabled
 			existingNode.Tag = node.Tag
+			existingNode.Tags = node.Tags
 
 			// Handle node name based on keepNodeName setting
 			if !keepNodeName {
@@ -640,6 +642,7 @@ func syncSingleExternalSubscription(ctx context.Context, client *http.Client, re
 				continue
 			}
 
+			touchedNodeIDs[existingNode.ID] = true
 			logger.Info("[外部订阅同步] 成功更新节点 (ID)", "node_name", existingNode.NodeName, "id", existingNode.ID)
 
 			// Sync to YAML files (handle name change if needed)
@@ -655,11 +658,12 @@ func syncSingleExternalSubscription(ctx context.Context, client *http.Client, re
 			// New node not found in existing nodes
 			// Check sync scope: only create new nodes if syncScope is "all"
 			if syncScope == "all" {
-				_, err := repo.CreateNode(ctx, node)
+				createdNode, err := repo.CreateNode(ctx, node)
 				if err != nil {
 					logger.Info("[外部订阅同步] 创建新节点 失败", "node_name", node.NodeName, "error", err)
 					continue
 				}
+				touchedNodeIDs[createdNode.ID] = true
 				logger.Info("[外部订阅同步] 成功创建新节点", "node_name", node.NodeName)
 				syncedCount++
 				createdCount++
@@ -672,11 +676,42 @@ func syncSingleExternalSubscription(ctx context.Context, client *http.Client, re
 
 	logger.Info("[外部订阅同步] 订阅同步完成", "name", sub.Name, "synced_count", syncedCount, "total_count", len(nodesToUpdate), "updated", updatedCount, "created", createdCount, "skipped", skippedCount)
 
+	// 清理该外部订阅中已不存在的节点（仅 syncScope=all），保证聚合订阅能随源节点减少而减少
+	if syncScope == "all" {
+		removedOrphans := 0
+		for _, existing := range existingNodes {
+			if existing.RawURL != sub.URL {
+				continue
+			}
+			if touchedNodeIDs[existing.ID] {
+				continue
+			}
+			if err := repo.DeleteNodeForSync(ctx, existing.ID, username); err != nil {
+				logger.Info("[外部订阅同步] 删除失效节点失败", "node_name", existing.NodeName, "id", existing.ID, "error", err)
+				continue
+			}
+			removedOrphans++
+			logger.Info("[外部订阅同步] 删除失效节点", "node_name", existing.NodeName, "id", existing.ID)
+			if subscribeDir != "" {
+				if err := deleteNodeFromYAMLFiles(subscribeDir, existing.NodeName); err != nil {
+					logger.Info("[外部订阅同步] 从YAML删除失效节点失败", "node_name", existing.NodeName, "error", err)
+				}
+			}
+		}
+		if removedOrphans > 0 {
+			logger.Info("[外部订阅同步] 清理失效节点完成", "name", sub.Name, "removed_count", removedOrphans)
+		}
+	}
+
+
 	// 同步代理集合节点到 YAML（仅处理 mmw 模式）
 	if err := syncProxyProviderNodesToYAML(ctx, repo, subscribeDir, username, sub); err != nil {
 		logger.Info("[外部订阅同步] 同步代理集合节点到YAML失败", "error", err)
 		// 不影响主流程，仅记录日志
 	}
+
+	// 刷新绑定模板的订阅，使聚合/模板订阅及时反映节点变化
+	go RefreshAllTemplateSubscriptions(repo, username)
 
 	return syncedCount, sub, nil
 }

--- a/internal/handler/external_sync.go
+++ b/internal/handler/external_sync.go
@@ -1490,3 +1490,111 @@ func formatTrafficShort(bytes int64) string {
 	}
 	return fmt.Sprintf("%.0fMB", float64(bytes)/float64(mb))
 }
+
+
+// StartExternalSubscriptionAutoUpdateScheduler periodically syncs external subscriptions
+// that have AutoUpdate enabled, based on each subscription's UpdateIntervalMinutes.
+func StartExternalSubscriptionAutoUpdateScheduler(ctx context.Context, repo *storage.TrafficRepository, subscribeDir string) {
+	if repo == nil {
+		return
+	}
+
+	// 每分钟检查一次是否有到期的订阅
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	logger.Info("[外部订阅定时更新] 调度器已启动", "check_interval", "1分钟")
+
+	// 启动后稍等再跑第一轮，避免和启动其他任务抢资源
+	runExternalSubscriptionAutoUpdates(ctx, repo, subscribeDir)
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("[外部订阅定时更新] 调度器已停止")
+			return
+		case <-ticker.C:
+			runExternalSubscriptionAutoUpdates(ctx, repo, subscribeDir)
+		}
+	}
+}
+
+func runExternalSubscriptionAutoUpdates(ctx context.Context, repo *storage.TrafficRepository, subscribeDir string) {
+	if repo == nil {
+		return
+	}
+
+	// 独立超时，避免单次任务拖垮后续检查
+	runCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	subs, err := repo.ListAllExternalSubscriptions(runCtx)
+	if err != nil {
+		logger.Info("[外部订阅定时更新] 获取订阅列表失败", "error", err)
+		return
+	}
+
+	now := time.Now()
+	client := &http.Client{Timeout: 30 * time.Second}
+	settingsCache := make(map[string]storage.UserSettings)
+
+	synced := 0
+	for _, sub := range subs {
+		if !sub.AutoUpdate || sub.UpdateIntervalMinutes <= 0 {
+			continue
+		}
+
+		// 根据 last_sync_at 判断是否到期
+		if sub.LastSyncAt != nil {
+			elapsed := now.Sub(*sub.LastSyncAt)
+			if elapsed < time.Duration(sub.UpdateIntervalMinutes)*time.Minute {
+				continue
+			}
+		}
+
+		logger.Info("[外部订阅定时更新] 开始同步",
+			"user", sub.Username,
+			"name", sub.Name,
+			"interval_minutes", sub.UpdateIntervalMinutes)
+
+		userSettings, ok := settingsCache[sub.Username]
+		if !ok {
+			userSettings, err = repo.GetUserSettings(runCtx, sub.Username)
+			if err != nil {
+				logger.Info("[外部订阅定时更新] 获取用户设置失败，使用默认设置", "user", sub.Username, "error", err)
+				userSettings = storage.UserSettings{
+					MatchRule:      "node_name",
+					SyncScope:      "saved_only",
+					KeepNodeName:   true,
+					NodeNameFilter: defaultNodeNameFilterPattern,
+				}
+			}
+			settingsCache[sub.Username] = userSettings
+		}
+
+		nodeCount, updatedSub, err := syncSingleExternalSubscription(runCtx, client, repo, subscribeDir, sub.Username, sub, userSettings)
+		if err != nil {
+			logger.Info("[外部订阅定时更新] 同步失败", "user", sub.Username, "name", sub.Name, "error", err)
+			continue
+		}
+
+		syncTime := time.Now()
+		updatedSub.LastSyncAt = &syncTime
+		updatedSub.NodeCount = nodeCount
+		// 保留定时更新设置（sync 返回的 sub 已包含）
+		if err := repo.UpdateExternalSubscription(runCtx, updatedSub); err != nil {
+			logger.Info("[外部订阅定时更新] 更新同步时间失败", "user", sub.Username, "name", sub.Name, "error", err)
+			continue
+		}
+
+		synced++
+		logger.Info("[外部订阅定时更新] 同步完成",
+			"user", sub.Username,
+			"name", sub.Name,
+			"node_count", nodeCount)
+	}
+
+	if synced > 0 {
+		logger.Info("[外部订阅定时更新] 本轮完成", "synced", synced)
+	}
+}

--- a/internal/handler/subscribe_files.go
+++ b/internal/handler/subscribe_files.go
@@ -56,6 +56,8 @@ func (h *subscribeFilesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		h.handleUpload(w, r)
 	case path == "create-from-config" && r.Method == http.MethodPost:
 		h.handleCreateFromConfig(w, r)
+	case path == "create-aggregate" && r.Method == http.MethodPost:
+		h.handleCreateAggregate(w, r)
 	case strings.HasSuffix(path, "/users") && r.Method == http.MethodGet:
 		// GET /api/admin/subscribe-files/{id}/users
 		idStr := strings.TrimSuffix(path, "/users")
@@ -68,9 +70,9 @@ func (h *subscribeFilesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		// PUT /api/admin/subscribe-files/{filename}/content
 		filename := strings.TrimSuffix(path, "/content")
 		h.handleUpdateContent(w, r, filename)
-	case path != "" && path != "import" && path != "upload" && path != "create-from-config" && (r.Method == http.MethodPut || r.Method == http.MethodPatch):
+	case path != "" && path != "import" && path != "upload" && path != "create-from-config" && path != "create-aggregate" && (r.Method == http.MethodPut || r.Method == http.MethodPatch):
 		h.handleUpdate(w, r, path)
-	case path != "" && path != "import" && path != "upload" && path != "create-from-config" && r.Method == http.MethodDelete:
+	case path != "" && path != "import" && path != "upload" && path != "create-from-config" && path != "create-aggregate" && r.Method == http.MethodDelete:
 		h.handleDelete(w, r, path)
 	default:
 		allowed := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete}
@@ -1377,6 +1379,205 @@ func copyMap(m map[string]any) map[string]any {
 		}
 	}
 	return result
+}
+
+
+// handleCreateAggregate 聚合多个标签(通常为外部订阅名称)为一个新订阅。
+// 使用 selected_tags 动态绑定节点：源订阅更新后，聚合订阅在获取时也会反映最新节点集合。
+// 可选绑定 V3 模板；未绑定时按标签实时生成精简 Clash 配置。
+func (h *subscribeFilesHandler) handleCreateAggregate(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name             string   `json:"name"`
+		Description      string   `json:"description"`
+		Filename         string   `json:"filename"`
+		SelectedTags     []string `json:"selected_tags"`
+		TemplateFilename string   `json:"template_filename"`
+		TrafficLimit     *float64 `json:"traffic_limit"`
+		StatsServerIDs   string   `json:"stats_server_ids"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeBadRequest(w, "请求格式不正确")
+		return
+	}
+
+	req.Name = strings.TrimSpace(req.Name)
+	if req.Name == "" {
+		writeBadRequest(w, "订阅名称是必填项")
+		return
+	}
+
+	// normalize tags
+	tagSet := make(map[string]struct{})
+	var tags []string
+	for _, t := range req.SelectedTags {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		if _, ok := tagSet[t]; ok {
+			continue
+		}
+		tagSet[t] = struct{}{}
+		tags = append(tags, t)
+	}
+	if len(tags) == 0 {
+		writeBadRequest(w, "请至少选择一个源订阅/标签")
+		return
+	}
+
+	username := auth.UsernameFromContext(r.Context())
+	if username == "" {
+		writeError(w, http.StatusUnauthorized, errors.New("未登录"))
+		return
+	}
+
+	filename := strings.TrimSpace(req.Filename)
+	if filename == "" {
+		filename = req.Name
+	}
+	ext := filepath.Ext(filename)
+	if ext != ".yaml" && ext != ".yml" {
+		filename = filename + ".yaml"
+	}
+
+	description := strings.TrimSpace(req.Description)
+	if description == "" {
+		description = "聚合订阅: " + strings.Join(tags, ", ")
+	}
+
+	// Build initial content (also used as fallback file on disk)
+	content, err := buildAggregateConfigContent(r.Context(), h.repo, username, tags, strings.TrimSpace(req.TemplateFilename))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	subscribesDir := "subscribes"
+	if err := os.MkdirAll(subscribesDir, 0755); err != nil {
+		writeError(w, http.StatusInternalServerError, errors.New("创建订阅目录失败"))
+		return
+	}
+	filePath := filepath.Join(subscribesDir, filename)
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		writeError(w, http.StatusInternalServerError, errors.New("保存订阅文件失败"))
+		return
+	}
+
+	file := storage.SubscribeFile{
+		Name:             req.Name,
+		Description:      description,
+		URL:              "",
+		Type:             storage.SubscribeTypeCreate,
+		Filename:         filename,
+		TemplateFilename: strings.TrimSpace(req.TemplateFilename),
+		SelectedTags:     tags,
+		SelectedNodeIDs:  nil, // 必须为空：按标签动态跟踪源订阅节点变化
+		TrafficLimit:     req.TrafficLimit,
+		StatsServerIDs:   req.StatsServerIDs,
+	}
+
+	created, err := h.repo.CreateSubscribeFile(r.Context(), file)
+	if err != nil {
+		_ = os.Remove(filePath)
+		if errors.Is(err, storage.ErrSubscribeFileExists) {
+			writeError(w, http.StatusConflict, errors.New("订阅名称已存在"))
+			return
+		}
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	// 若绑定了模板，异步再刷一次确保与 regenerateFromTemplate 一致
+	if created.TemplateFilename != "" {
+		go func() {
+			ctx := context.Background()
+			if err := h.regenerateFromTemplate(ctx, username, created); err != nil {
+				logger.Info("[聚合订阅] 模板生成失败", "subscribe", created.Name, "error", err)
+			}
+		}()
+	}
+
+	respondJSON(w, http.StatusCreated, map[string]any{
+		"file": convertSubscribeFile(created),
+	})
+}
+
+// buildAggregateConfigContent 生成聚合订阅的初始 YAML 内容。
+// 有模板时走模板处理；无模板时生成精简 Clash 配置(proxies + 默认选择组)。
+func buildAggregateConfigContent(ctx context.Context, repo *storage.TrafficRepository, username string, tags []string, templateFilename string) ([]byte, error) {
+	nodes, err := repo.ListNodes(ctx, username)
+	if err != nil {
+		return nil, fmt.Errorf("获取节点列表失败: %w", err)
+	}
+
+	selectedTagsMap := make(map[string]bool, len(tags))
+	for _, t := range tags {
+		selectedTagsMap[t] = true
+	}
+
+	var proxies []map[string]any
+	var proxyNames []string
+	for _, node := range nodes {
+		if !node.Enabled {
+			continue
+		}
+		if !node.HasAnyTag(selectedTagsMap) {
+			continue
+		}
+		var proxyConfig map[string]any
+		if err := json.Unmarshal([]byte(node.ClashConfig), &proxyConfig); err != nil {
+			continue
+		}
+		proxyConfig["name"] = node.NodeName
+		proxies = append(proxies, proxyConfig)
+		proxyNames = append(proxyNames, node.NodeName)
+	}
+
+	if templateFilename != "" {
+		templatePath := filepath.Join("rule_templates", templateFilename)
+		templateContent, err := os.ReadFile(templatePath)
+		if err != nil {
+			return nil, fmt.Errorf("读取模板文件失败: %w", err)
+		}
+		// providers map 留空即可；模板处理器主要消费 proxies
+		processor := substore.NewTemplateV3Processor(nil, map[string][]string{})
+		result, err := processor.ProcessTemplate(string(templateContent), proxies)
+		if err != nil {
+			return nil, fmt.Errorf("处理模板失败: %w", err)
+		}
+		result, err = injectProxiesIntoTemplate(result, proxies)
+		if err != nil {
+			return nil, fmt.Errorf("注入代理节点失败: %w", err)
+		}
+		return []byte(result), nil
+	}
+
+	// 无模板：精简配置，客户端可直接使用
+	groupProxies := append([]string{}, proxyNames...)
+	groupProxies = append(groupProxies, "DIRECT")
+	cfg := map[string]any{
+		"mixed-port":         7890,
+		"allow-lan":          true,
+		"mode":               "rule",
+		"log-level":          "info",
+		"external-controller": "127.0.0.1:9090",
+		"proxies":            proxies,
+		"proxy-groups": []map[string]any{
+			{
+				"name":    "PROXY",
+				"type":    "select",
+				"proxies": groupProxies,
+			},
+		},
+		"rules": []string{
+			"MATCH,PROXY",
+		},
+	}
+	out, err := yaml.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("序列化配置失败: %w", err)
+	}
+	return out, nil
 }
 
 // regenerateFromTemplate 从V3模板重新生成订阅文件

--- a/internal/handler/subscription.go
+++ b/internal/handler/subscription.go
@@ -376,6 +376,21 @@ func (h *SubscriptionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
+	// 聚合订阅/标签动态生成：未绑定模板但配置了 selected_tags 时，按标签实时从节点表生成配置
+	// 不使用 selected_node_ids（固定 ID 无法跟踪源订阅节点增删）
+	if len(data) == 0 && hasSubscribeFile && subscribeFile.TemplateFilename == "" &&
+		len(subscribeFile.SelectedTags) > 0 && len(subscribeFile.SelectedNodeIDs) == 0 {
+		stepStart = time.Now()
+		tagData, err := h.generateFromSelectedTags(r.Context(), username, subscribeFile)
+		if err != nil {
+			logger.Info("[Subscription] 按标签动态生成失败，回退到原始文件", "error", err, "tags", subscribeFile.SelectedTags)
+		} else {
+			data = tagData
+			fromTemplate = true // 跳过基于磁盘文件的 MMW 同步，避免覆盖动态内容
+			logger.Info("[Subscription] 按标签动态生成完成", "tags", subscribeFile.SelectedTags, "bytes", len(data), "duration_ms", time.Since(stepStart).Milliseconds())
+		}
+	}
+
 	// 文件读取（如果模板生成失败或未绑定模板）
 	if len(data) == 0 {
 		stepStart = time.Now()
@@ -2509,6 +2524,95 @@ func (h *SubscriptionHandler) generateFromTemplate(ctx context.Context, username
 	logger.Info("[模板生成] 模板处理完成", "subscribe", subscribeFile.Name, "template", subscribeFile.TemplateFilename, "result_bytes", len(result))
 
 	return []byte(result), nil
+}
+
+
+// generateFromSelectedTags 按订阅配置的 selected_tags 从节点表实时生成精简 Clash 配置。
+// 用于聚合订阅：源外部订阅节点增删/更新后，获取订阅时自动反映最新节点集合。
+func (h *SubscriptionHandler) generateFromSelectedTags(ctx context.Context, username string, subscribeFile storage.SubscribeFile) ([]byte, error) {
+	if len(subscribeFile.SelectedTags) == 0 {
+		return nil, errors.New("订阅未配置标签过滤")
+	}
+
+	nodeOwner := username
+	if user, err := h.repo.GetUser(ctx, username); err == nil && user.Role != storage.RoleAdmin {
+		if adminName, err := h.repo.GetAdminUsername(ctx); err == nil {
+			nodeOwner = adminName
+		}
+	}
+	nodes, err := h.repo.ListNodes(ctx, nodeOwner)
+	if err != nil {
+		return nil, fmt.Errorf("获取节点列表失败: %w", err)
+	}
+
+	if settings, err := h.repo.GetUserSettings(ctx, username); err == nil && len(settings.NodeOrder) > 0 {
+		sortNodesByNodeOrder(nodes, settings.NodeOrder)
+	}
+
+	selectedTagsMap := make(map[string]bool, len(subscribeFile.SelectedTags))
+	for _, tag := range subscribeFile.SelectedTags {
+		selectedTagsMap[tag] = true
+	}
+
+	nodeIDToName := make(map[int64]string, len(nodes))
+	for _, node := range nodes {
+		nodeIDToName[node.ID] = node.NodeName
+	}
+
+	var proxies []map[string]any
+	var proxyNames []string
+	for _, node := range nodes {
+		if !node.Enabled {
+			continue
+		}
+		if !node.HasAnyTag(selectedTagsMap) {
+			continue
+		}
+		var proxyConfig map[string]any
+		if err := json.Unmarshal([]byte(node.ClashConfig), &proxyConfig); err != nil {
+			logger.Info("[标签动态生成] 解析节点配置失败，跳过", "node", node.NodeName, "error", err)
+			continue
+		}
+		proxyConfig["name"] = node.NodeName
+		if node.ChainProxyNodeID != nil {
+			if targetName, ok := nodeIDToName[*node.ChainProxyNodeID]; ok {
+				proxyConfig["dialer-proxy"] = targetName
+			}
+		}
+		if len(node.RelayGroupNodeIDs) > 0 && node.RelayGroupName != "" {
+			proxyConfig["dialer-proxy"] = node.RelayGroupName
+		}
+		proxies = append(proxies, proxyConfig)
+		proxyNames = append(proxyNames, node.NodeName)
+	}
+
+	groupProxies := append([]string{}, proxyNames...)
+	groupProxies = append(groupProxies, "DIRECT")
+	cfg := map[string]any{
+		"mixed-port":          7890,
+		"allow-lan":           true,
+		"mode":                "rule",
+		"log-level":           "info",
+		"external-controller": "127.0.0.1:9090",
+		"proxies":             proxies,
+		"proxy-groups": []map[string]any{
+			{
+				"name":    "PROXY",
+				"type":    "select",
+				"proxies": groupProxies,
+			},
+		},
+		"rules": []string{
+			"MATCH,PROXY",
+		},
+	}
+
+	out, err := yaml.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("序列化配置失败: %w", err)
+	}
+	logger.Info("[标签动态生成] 完成", "subscribe", subscribeFile.Name, "tags", subscribeFile.SelectedTags, "proxy_count", len(proxies))
+	return out, nil
 }
 
 // createSubInfoNodes creates subscription info nodes (expire time and remaining traffic)

--- a/internal/storage/traffic.go
+++ b/internal/storage/traffic.go
@@ -313,20 +313,22 @@ type SystemConfig struct {
 
 // ExternalSubscription represents an external subscription URL imported by user.
 type ExternalSubscription struct {
-	ID          int64
-	Username    string
-	Name        string
-	URL         string
-	UserAgent   string // User-Agent 请求头
-	NodeCount   int
-	LastSyncAt  *time.Time
-	Upload      int64      // 已上传流量（字节）
-	Download    int64      // 已下载流量（字节）
-	Total       int64      // 总流量（字节）
-	Expire      *time.Time // 过期时间
-	TrafficMode string     // 流量统计方式: "download", "upload", "both", "none"
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID                    int64
+	Username              string
+	Name                  string
+	URL                   string
+	UserAgent             string // User-Agent 请求头
+	NodeCount             int
+	LastSyncAt            *time.Time
+	Upload                int64      // 已上传流量（字节）
+	Download              int64      // 已下载流量（字节）
+	Total                 int64      // 总流量（字节）
+	Expire                *time.Time // 过期时间
+	TrafficMode           string     // 流量统计方式: "download", "upload", "both", "none"
+	AutoUpdate            bool       // 是否定时自动更新此订阅
+	UpdateIntervalMinutes int        // 定时更新间隔（分钟），>0 且 AutoUpdate 时生效
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
 }
 
 // OverrideScript represents a JavaScript override script.
@@ -844,6 +846,12 @@ CREATE INDEX IF NOT EXISTS idx_external_subscriptions_url ON external_subscripti
 		return err
 	}
 	if err := r.ensureExternalSubscriptionColumn("traffic_mode", "TEXT NOT NULL DEFAULT 'both'"); err != nil {
+		return err
+	}
+	if err := r.ensureExternalSubscriptionColumn("auto_update", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
+	}
+	if err := r.ensureExternalSubscriptionColumn("update_interval_minutes", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return err
 	}
 
@@ -3868,7 +3876,7 @@ func (r *TrafficRepository) ListExternalSubscriptions(ctx context.Context, usern
 		return nil, errors.New("username is required")
 	}
 
-	const stmt = `SELECT id, username, name, url, COALESCE(user_agent, 'clash-meta/2.4.0'), node_count, last_sync_at, COALESCE(upload, 0), COALESCE(download, 0), COALESCE(total, 0), expire, COALESCE(traffic_mode, 'both'), created_at, updated_at FROM external_subscriptions WHERE username = ? ORDER BY created_at DESC`
+	const stmt = `SELECT id, username, name, url, COALESCE(user_agent, 'clash-meta/2.4.0'), node_count, last_sync_at, COALESCE(upload, 0), COALESCE(download, 0), COALESCE(total, 0), expire, COALESCE(traffic_mode, 'both'), COALESCE(auto_update, 0), COALESCE(update_interval_minutes, 0), created_at, updated_at FROM external_subscriptions WHERE username = ? ORDER BY created_at DESC`
 	rows, err := r.db.QueryContext(ctx, stmt, username)
 	if err != nil {
 		return nil, fmt.Errorf("list external subscriptions: %w", err)
@@ -3879,9 +3887,11 @@ func (r *TrafficRepository) ListExternalSubscriptions(ctx context.Context, usern
 	for rows.Next() {
 		var sub ExternalSubscription
 		var lastSyncAt, expire sql.NullTime
-		if err := rows.Scan(&sub.ID, &sub.Username, &sub.Name, &sub.URL, &sub.UserAgent, &sub.NodeCount, &lastSyncAt, &sub.Upload, &sub.Download, &sub.Total, &expire, &sub.TrafficMode, &sub.CreatedAt, &sub.UpdatedAt); err != nil {
+		var autoUpdate int
+		if err := rows.Scan(&sub.ID, &sub.Username, &sub.Name, &sub.URL, &sub.UserAgent, &sub.NodeCount, &lastSyncAt, &sub.Upload, &sub.Download, &sub.Total, &expire, &sub.TrafficMode, &autoUpdate, &sub.UpdateIntervalMinutes, &sub.CreatedAt, &sub.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan external subscription: %w", err)
 		}
+		sub.AutoUpdate = autoUpdate != 0
 		if lastSyncAt.Valid {
 			sub.LastSyncAt = &lastSyncAt.Time
 		}
@@ -3914,15 +3924,17 @@ func (r *TrafficRepository) GetExternalSubscription(ctx context.Context, id int6
 		return sub, errors.New("username is required")
 	}
 
-	const stmt = `SELECT id, username, name, url, COALESCE(user_agent, 'clash-meta/2.4.0'), node_count, last_sync_at, COALESCE(upload, 0), COALESCE(download, 0), COALESCE(total, 0), expire, COALESCE(traffic_mode, 'both'), created_at, updated_at FROM external_subscriptions WHERE id = ? AND username = ? LIMIT 1`
+	const stmt = `SELECT id, username, name, url, COALESCE(user_agent, 'clash-meta/2.4.0'), node_count, last_sync_at, COALESCE(upload, 0), COALESCE(download, 0), COALESCE(total, 0), expire, COALESCE(traffic_mode, 'both'), COALESCE(auto_update, 0), COALESCE(update_interval_minutes, 0), created_at, updated_at FROM external_subscriptions WHERE id = ? AND username = ? LIMIT 1`
 	var lastSyncAt, expire sql.NullTime
-	err := r.db.QueryRowContext(ctx, stmt, id, username).Scan(&sub.ID, &sub.Username, &sub.Name, &sub.URL, &sub.UserAgent, &sub.NodeCount, &lastSyncAt, &sub.Upload, &sub.Download, &sub.Total, &expire, &sub.TrafficMode, &sub.CreatedAt, &sub.UpdatedAt)
+	var autoUpdate int
+	err := r.db.QueryRowContext(ctx, stmt, id, username).Scan(&sub.ID, &sub.Username, &sub.Name, &sub.URL, &sub.UserAgent, &sub.NodeCount, &lastSyncAt, &sub.Upload, &sub.Download, &sub.Total, &expire, &sub.TrafficMode, &autoUpdate, &sub.UpdateIntervalMinutes, &sub.CreatedAt, &sub.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return sub, ErrExternalSubscriptionNotFound
 		}
 		return sub, fmt.Errorf("get external subscription: %w", err)
 	}
+	sub.AutoUpdate = autoUpdate != 0
 
 	if lastSyncAt.Valid {
 		sub.LastSyncAt = &lastSyncAt.Time
@@ -3931,6 +3943,42 @@ func (r *TrafficRepository) GetExternalSubscription(ctx context.Context, id int6
 		sub.Expire = &expire.Time
 	}
 
+	return sub, nil
+}
+
+// GetExternalSubscriptionByURL retrieves an external subscription by username and URL.
+func (r *TrafficRepository) GetExternalSubscriptionByURL(ctx context.Context, username, url string) (ExternalSubscription, error) {
+	var sub ExternalSubscription
+	if r == nil || r.db == nil {
+		return sub, errors.New("traffic repository not initialized")
+	}
+
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return sub, errors.New("username is required")
+	}
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return sub, errors.New("subscription url is required")
+	}
+
+	const stmt = `SELECT id, username, name, url, COALESCE(user_agent, 'clash-meta/2.4.0'), node_count, last_sync_at, COALESCE(upload, 0), COALESCE(download, 0), COALESCE(total, 0), expire, COALESCE(traffic_mode, 'both'), COALESCE(auto_update, 0), COALESCE(update_interval_minutes, 0), created_at, updated_at FROM external_subscriptions WHERE username = ? AND url = ? LIMIT 1`
+	var lastSyncAt, expire sql.NullTime
+	var autoUpdate int
+	err := r.db.QueryRowContext(ctx, stmt, username, url).Scan(&sub.ID, &sub.Username, &sub.Name, &sub.URL, &sub.UserAgent, &sub.NodeCount, &lastSyncAt, &sub.Upload, &sub.Download, &sub.Total, &expire, &sub.TrafficMode, &autoUpdate, &sub.UpdateIntervalMinutes, &sub.CreatedAt, &sub.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return sub, ErrExternalSubscriptionNotFound
+		}
+		return sub, fmt.Errorf("get external subscription by url: %w", err)
+	}
+	sub.AutoUpdate = autoUpdate != 0
+	if lastSyncAt.Valid {
+		sub.LastSyncAt = &lastSyncAt.Time
+	}
+	if expire.Valid {
+		sub.Expire = &expire.Time
+	}
 	return sub, nil
 }
 
@@ -3965,8 +4013,17 @@ func (r *TrafficRepository) CreateExternalSubscription(ctx context.Context, sub 
 		trafficMode = "both"
 	}
 
-	const stmt = `INSERT INTO external_subscriptions (username, name, url, user_agent, node_count, last_sync_at, upload, download, total, expire, traffic_mode) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-	result, err := r.db.ExecContext(ctx, stmt, username, name, url, userAgent, sub.NodeCount, sub.LastSyncAt, sub.Upload, sub.Download, sub.Total, sub.Expire, trafficMode)
+	autoUpdate := 0
+	if sub.AutoUpdate {
+		autoUpdate = 1
+	}
+	updateInterval := sub.UpdateIntervalMinutes
+	if updateInterval < 0 {
+		updateInterval = 0
+	}
+
+	const stmt = `INSERT INTO external_subscriptions (username, name, url, user_agent, node_count, last_sync_at, upload, download, total, expire, traffic_mode, auto_update, update_interval_minutes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	result, err := r.db.ExecContext(ctx, stmt, username, name, url, userAgent, sub.NodeCount, sub.LastSyncAt, sub.Upload, sub.Download, sub.Total, sub.Expire, trafficMode, autoUpdate, updateInterval)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
 			return 0, ErrExternalSubscriptionExists
@@ -4017,8 +4074,17 @@ func (r *TrafficRepository) UpdateExternalSubscription(ctx context.Context, sub 
 		trafficMode = "both"
 	}
 
-	const stmt = `UPDATE external_subscriptions SET name = ?, url = ?, user_agent = ?, node_count = ?, last_sync_at = ?, upload = ?, download = ?, total = ?, expire = ?, traffic_mode = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND username = ?`
-	result, err := r.db.ExecContext(ctx, stmt, name, url, userAgent, sub.NodeCount, sub.LastSyncAt, sub.Upload, sub.Download, sub.Total, sub.Expire, trafficMode, sub.ID, username)
+	autoUpdate := 0
+	if sub.AutoUpdate {
+		autoUpdate = 1
+	}
+	updateInterval := sub.UpdateIntervalMinutes
+	if updateInterval < 0 {
+		updateInterval = 0
+	}
+
+	const stmt = `UPDATE external_subscriptions SET name = ?, url = ?, user_agent = ?, node_count = ?, last_sync_at = ?, upload = ?, download = ?, total = ?, expire = ?, traffic_mode = ?, auto_update = ?, update_interval_minutes = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND username = ?`
+	result, err := r.db.ExecContext(ctx, stmt, name, url, userAgent, sub.NodeCount, sub.LastSyncAt, sub.Upload, sub.Download, sub.Total, sub.Expire, trafficMode, autoUpdate, updateInterval, sub.ID, username)
 	if err != nil {
 		return fmt.Errorf("update external subscription: %w", err)
 	}
@@ -4365,7 +4431,7 @@ func (r *TrafficRepository) ListAllExternalSubscriptions(ctx context.Context) ([
 		return nil, errors.New("traffic repository not initialized")
 	}
 
-	const stmt = `SELECT id, username, name, url, COALESCE(user_agent, 'clash-meta/2.4.0'), node_count, last_sync_at, COALESCE(upload, 0), COALESCE(download, 0), COALESCE(total, 0), expire, COALESCE(traffic_mode, 'both'), created_at, updated_at FROM external_subscriptions ORDER BY created_at DESC`
+	const stmt = `SELECT id, username, name, url, COALESCE(user_agent, 'clash-meta/2.4.0'), node_count, last_sync_at, COALESCE(upload, 0), COALESCE(download, 0), COALESCE(total, 0), expire, COALESCE(traffic_mode, 'both'), COALESCE(auto_update, 0), COALESCE(update_interval_minutes, 0), created_at, updated_at FROM external_subscriptions ORDER BY created_at DESC`
 	rows, err := r.db.QueryContext(ctx, stmt)
 	if err != nil {
 		return nil, fmt.Errorf("list all external subscriptions: %w", err)
@@ -4377,9 +4443,11 @@ func (r *TrafficRepository) ListAllExternalSubscriptions(ctx context.Context) ([
 		var sub ExternalSubscription
 		var lastSyncAt sql.NullTime
 		var expire sql.NullTime
-		if err := rows.Scan(&sub.ID, &sub.Username, &sub.Name, &sub.URL, &sub.UserAgent, &sub.NodeCount, &lastSyncAt, &sub.Upload, &sub.Download, &sub.Total, &expire, &sub.TrafficMode, &sub.CreatedAt, &sub.UpdatedAt); err != nil {
+		var autoUpdate int
+		if err := rows.Scan(&sub.ID, &sub.Username, &sub.Name, &sub.URL, &sub.UserAgent, &sub.NodeCount, &lastSyncAt, &sub.Upload, &sub.Download, &sub.Total, &expire, &sub.TrafficMode, &autoUpdate, &sub.UpdateIntervalMinutes, &sub.CreatedAt, &sub.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan external subscription: %w", err)
 		}
+		sub.AutoUpdate = autoUpdate != 0
 		if lastSyncAt.Valid {
 			sub.LastSyncAt = &lastSyncAt.Time
 		}

--- a/miaomiaowu/src/components/clash-config-viewer.tsx
+++ b/miaomiaowu/src/components/clash-config-viewer.tsx
@@ -1,0 +1,190 @@
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { Check, Copy, Download, Eye, Pencil } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+type ClashConfigViewerProps = {
+  value: string
+  onChange: (value: string) => void
+  className?: string
+  height?: number
+}
+
+const LINE_HEIGHT = 18
+/** 超过该行数默认只读虚拟列表，避免巨型 textarea 拖垮页面 */
+const AUTO_VIEW_LINES = 200
+/** 超过该字符数也强制默认预览模式 */
+const AUTO_VIEW_CHARS = 40_000
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  return `${(n / (1024 * 1024)).toFixed(2)} MB`
+}
+
+export const ClashConfigViewer = memo(function ClashConfigViewer({
+  value,
+  onChange,
+  className,
+  height = 400,
+}: ClashConfigViewerProps) {
+  const lines = useMemo(() => (value.length ? value.split('\n') : ['']), [value])
+  const lineCount = lines.length
+  const isLarge = lineCount >= AUTO_VIEW_LINES || value.length >= AUTO_VIEW_CHARS
+
+  const [mode, setMode] = useState<'view' | 'edit'>('view')
+  const [draft, setDraft] = useState(value)
+  const [copied, setCopied] = useState(false)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  // 避免外部 value 与本地编辑互相抢写
+  const editingRef = useRef(false)
+
+  useEffect(() => {
+    if (editingRef.current) return
+    setDraft(value)
+  }, [value])
+
+  const virtualizer = useVirtualizer({
+    count: lineCount,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => LINE_HEIGHT,
+    overscan: 24,
+  })
+
+  const enterEdit = useCallback(() => {
+    setDraft(value)
+    editingRef.current = true
+    setMode('edit')
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus()
+    })
+  }, [value])
+
+  const applyEdit = useCallback(() => {
+    editingRef.current = false
+    onChange(draft)
+    setMode('view')
+  }, [draft, onChange])
+
+  const cancelEdit = useCallback(() => {
+    editingRef.current = false
+    setDraft(value)
+    setMode('view')
+  }, [value])
+
+  const handleCopy = useCallback(async () => {
+    const text = mode === 'edit' ? draft : value
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      toast.success('配置已复制到剪贴板')
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      toast.error('复制失败，请手动选择文本')
+    }
+  }, [draft, mode, value])
+
+  const handleDownload = useCallback(() => {
+    const text = mode === 'edit' ? draft : value
+    const blob = new Blob([text], { type: 'text/yaml;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'clash-config.yaml'
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    URL.revokeObjectURL(url)
+    toast.success('已开始下载配置文件')
+  }, [draft, mode, value])
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      <div className='flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground'>
+        <span>
+          {lineCount.toLocaleString()} 行 · {formatBytes(value.length)}
+          {isLarge && mode === 'view' ? ' · 预览模式（虚拟滚动）' : ''}
+          {mode === 'edit' ? ' · 编辑中（本地缓冲，完成后再写回）' : ''}
+        </span>
+        <div className='flex flex-wrap items-center gap-1'>
+          <Button type='button' variant='outline' size='sm' className='h-8' onClick={handleCopy}>
+            {copied ? <Check className='h-3.5 w-3.5' /> : <Copy className='h-3.5 w-3.5' />}
+            <span className='ml-1'>{copied ? '已复制' : '复制'}</span>
+          </Button>
+          <Button type='button' variant='outline' size='sm' className='h-8' onClick={handleDownload}>
+            <Download className='h-3.5 w-3.5' />
+            <span className='ml-1'>下载</span>
+          </Button>
+          {mode === 'view' ? (
+            <Button type='button' variant='outline' size='sm' className='h-8' onClick={enterEdit}>
+              <Pencil className='h-3.5 w-3.5' />
+              <span className='ml-1'>编辑</span>
+            </Button>
+          ) : (
+            <>
+              <Button type='button' variant='outline' size='sm' className='h-8' onClick={cancelEdit}>
+                <Eye className='h-3.5 w-3.5' />
+                <span className='ml-1'>取消</span>
+              </Button>
+              <Button type='button' size='sm' className='h-8' onClick={applyEdit}>
+                完成编辑
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {mode === 'view' ? (
+        <div
+          ref={scrollRef}
+          className='rounded-lg border bg-muted/30 overflow-auto font-mono text-xs overscroll-contain'
+          style={{ height, maxHeight: height }}
+        >
+          <div
+            className='relative w-full'
+            style={{ height: virtualizer.getTotalSize() }}
+          >
+            {virtualizer.getVirtualItems().map((item) => (
+              <div
+                key={item.key}
+                className='absolute left-0 top-0 flex w-max min-w-full whitespace-pre px-3 text-[12px] leading-[18px] text-foreground/90'
+                style={{
+                  height: item.size,
+                  transform: `translateY(${item.start}px)`,
+                }}
+              >
+                <span className='mr-3 inline-block w-10 select-none text-right text-muted-foreground/70'>
+                  {item.index + 1}
+                </span>
+                <span>{lines[item.index] ?? ''}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className='rounded-lg border bg-muted/30'>
+          {isLarge && (
+            <div className='border-b px-3 py-2 text-xs text-amber-600 dark:text-amber-400'>
+              配置较大，编辑时请尽量少改；编辑完成前不会触发整页重渲染。
+            </div>
+          )}
+          <textarea
+            ref={textareaRef}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            spellCheck={false}
+            autoComplete='off'
+            autoCorrect='off'
+            autoCapitalize='off'
+            className='w-full resize-none overflow-auto border-0 bg-transparent px-3 py-2 font-mono text-xs leading-[18px] outline-none focus:ring-0 [field-sizing:fixed]'
+            style={{ height, maxHeight: height }}
+            placeholder='生成配置后显示在这里...'
+          />
+        </div>
+      )}
+    </div>
+  )
+})

--- a/miaomiaowu/src/routes/generator.tsx
+++ b/miaomiaowu/src/routes/generator.tsx
@@ -1,10 +1,11 @@
 import { useState, useMemo, useEffect } from 'react'
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Loader2, Save, Layers, Activity, MapPin, Plus, Eye, Pencil, Trash2, Settings, FileText, Upload } from 'lucide-react'
+import { Loader2, Save, Layers, Activity, MapPin, Plus, Eye, Pencil, Trash2, Settings, FileText, Upload, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react'
 import { Topbar } from '@/components/layout/topbar'
 import { useAuthStore } from '@/stores/auth-store'
 import { api } from '@/lib/api'
+import { getPageNumbers } from '@/lib/utils'
 import { EditNodesDialog } from '@/components/edit-nodes-dialog'
 import { MobileEditNodesDialog } from '@/components/mobile-edit-nodes-dialog'
 import { useMediaQuery } from '@/hooks/use-media-query'
@@ -242,6 +243,8 @@ function SubscriptionGeneratorPage() {
   const [loading, setLoading] = useState(false)
   const [clashConfig, setClashConfig] = useState('')
   const [selectedNodeIds, setSelectedNodeIds] = useState<Set<number>>(new Set())
+  const [nodeListPage, setNodeListPage] = useState(1)
+  const [nodeListPageSize, setNodeListPageSize] = useState(50)
   const [selectedProtocols, setSelectedProtocols] = useState<Set<string>>(new Set())
 
   // Fetch proxy group categories for ClashConfigBuilder
@@ -835,6 +838,28 @@ function SubscriptionGeneratorPage() {
       return true
     })
   }, [sortedEnabledNodes, selectedProtocols, selectedTags])
+
+  // 节点列表分页
+  useEffect(() => {
+    setNodeListPage(1)
+  }, [selectedProtocols, selectedTags, sortedEnabledNodes.length])
+
+  const nodeListTotalPages = Math.max(1, Math.ceil(filteredNodes.length / nodeListPageSize) || 1)
+  useEffect(() => {
+    if (nodeListPage > nodeListTotalPages) setNodeListPage(nodeListTotalPages)
+  }, [nodeListPage, nodeListTotalPages])
+
+  const paginatedNodes = useMemo(() => {
+    const start = (nodeListPage - 1) * nodeListPageSize
+    return filteredNodes.slice(start, start + nodeListPageSize)
+  }, [filteredNodes, nodeListPage, nodeListPageSize])
+
+  const nodeListRangeLabel = useMemo(() => {
+    if (filteredNodes.length === 0) return '0'
+    const start = (nodeListPage - 1) * nodeListPageSize + 1
+    const end = Math.min(nodeListPage * nodeListPageSize, filteredNodes.length)
+    return `${start}-${end}`
+  }, [filteredNodes.length, nodeListPage, nodeListPageSize])
 
   const handleToggleNode = (nodeId: number) => {
     const newSet = new Set(selectedNodeIds)
@@ -2381,8 +2406,98 @@ function SubscriptionGeneratorPage() {
                     </div>
                   )}
 
+                  <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between text-sm text-muted-foreground'>
+                    <span>
+                      共 {filteredNodes.length} 个节点
+                      {filteredNodes.length > 0 && <> · 显示 {nodeListRangeLabel}</>}
+                      {filteredNodes.length > 0 && <> · 第 {nodeListPage}/{nodeListTotalPages} 页</>}
+                    </span>
+                    <div className='flex flex-wrap items-center gap-2'>
+                      <span>每页</span>
+                      <Select
+                        value={String(nodeListPageSize)}
+                        onValueChange={(v) => {
+                          setNodeListPageSize(Number(v))
+                          setNodeListPage(1)
+                        }}
+                      >
+                        <SelectTrigger className='h-8 w-[96px]'>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {[20, 50, 100, 200].map((size) => (
+                            <SelectItem key={size} value={String(size)}>
+                              {size}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      {filteredNodes.length > 0 && (
+                        <div className='flex flex-wrap items-center gap-1'>
+                          <Button
+                            variant='outline'
+                            size='icon'
+                            className='h-8 w-8'
+                            disabled={nodeListPage <= 1}
+                            onClick={() => setNodeListPage(1)}
+                            title='第一页'
+                          >
+                            <ChevronsLeft className='h-4 w-4' />
+                          </Button>
+                          <Button
+                            variant='outline'
+                            size='icon'
+                            className='h-8 w-8'
+                            disabled={nodeListPage <= 1}
+                            onClick={() => setNodeListPage((p) => Math.max(1, p - 1))}
+                            title='上一页'
+                          >
+                            <ChevronLeft className='h-4 w-4' />
+                          </Button>
+                          {getPageNumbers(nodeListPage, nodeListTotalPages).map((page, idx) =>
+                            page === '...' ? (
+                              <span key={`top-ellipsis-${idx}`} className='px-1 text-muted-foreground'>
+                                ...
+                              </span>
+                            ) : (
+                              <Button
+                                key={`top-${page}`}
+                                variant={page === nodeListPage ? 'default' : 'outline'}
+                                size='sm'
+                                className='h-8 min-w-8 px-2'
+                                onClick={() => setNodeListPage(page as number)}
+                              >
+                                {page}
+                              </Button>
+                            )
+                          )}
+                          <Button
+                            variant='outline'
+                            size='icon'
+                            className='h-8 w-8'
+                            disabled={nodeListPage >= nodeListTotalPages}
+                            onClick={() => setNodeListPage((p) => Math.min(nodeListTotalPages, p + 1))}
+                            title='下一页'
+                          >
+                            <ChevronRight className='h-4 w-4' />
+                          </Button>
+                          <Button
+                            variant='outline'
+                            size='icon'
+                            className='h-8 w-8'
+                            disabled={nodeListPage >= nodeListTotalPages}
+                            onClick={() => setNodeListPage(nodeListTotalPages)}
+                            title='最后一页'
+                          >
+                            <ChevronsRight className='h-4 w-4' />
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
                   <DataTable
-                    data={filteredNodes}
+                    data={paginatedNodes}
                     getRowKey={(node) => node.id}
                     emptyText='没有找到匹配的节点'
                     containerClassName='max-h-[440px] overflow-y-auto'
@@ -2514,6 +2629,73 @@ function SubscriptionGeneratorPage() {
                       fields: []
                     }}
                   />
+
+                  {filteredNodes.length > 0 && (
+                    <div className='flex flex-col gap-3 border-t pt-3 sm:flex-row sm:items-center sm:justify-between'>
+                      <span className='text-sm text-muted-foreground'>
+                        第 {nodeListPage}/{nodeListTotalPages} 页 · 共 {filteredNodes.length} 个
+                      </span>
+                      <div className='flex flex-wrap items-center gap-1'>
+                        <Button
+                          variant='outline'
+                          size='icon'
+                          className='h-8 w-8'
+                          disabled={nodeListPage <= 1}
+                          onClick={() => setNodeListPage(1)}
+                          title='第一页'
+                        >
+                          <ChevronsLeft className='h-4 w-4' />
+                        </Button>
+                        <Button
+                          variant='outline'
+                          size='icon'
+                          className='h-8 w-8'
+                          disabled={nodeListPage <= 1}
+                          onClick={() => setNodeListPage((p) => Math.max(1, p - 1))}
+                          title='上一页'
+                        >
+                          <ChevronLeft className='h-4 w-4' />
+                        </Button>
+                        {getPageNumbers(nodeListPage, nodeListTotalPages).map((page, idx) =>
+                          page === '...' ? (
+                            <span key={`ellipsis-${idx}`} className='px-1 text-muted-foreground'>
+                              ...
+                            </span>
+                          ) : (
+                            <Button
+                              key={page}
+                              variant={page === nodeListPage ? 'default' : 'outline'}
+                              size='sm'
+                              className='h-8 min-w-8 px-2'
+                              onClick={() => setNodeListPage(page as number)}
+                            >
+                              {page}
+                            </Button>
+                          )
+                        )}
+                        <Button
+                          variant='outline'
+                          size='icon'
+                          className='h-8 w-8'
+                          disabled={nodeListPage >= nodeListTotalPages}
+                          onClick={() => setNodeListPage((p) => Math.min(nodeListTotalPages, p + 1))}
+                          title='下一页'
+                        >
+                          <ChevronRight className='h-4 w-4' />
+                        </Button>
+                        <Button
+                          variant='outline'
+                          size='icon'
+                          className='h-8 w-8'
+                          disabled={nodeListPage >= nodeListTotalPages}
+                          onClick={() => setNodeListPage(nodeListTotalPages)}
+                          title='最后一页'
+                        >
+                          <ChevronsRight className='h-4 w-4' />
+                        </Button>
+                      </div>
+                    </div>
+                  )}
                 </>
               )}
 
@@ -2829,7 +3011,7 @@ function SubscriptionGeneratorPage() {
                   <Textarea
                     value={clashConfig}
                     onChange={(e) => setClashConfig(e.target.value)}
-                    className='min-h-[400px] resize-none border-0 bg-transparent font-mono text-xs'
+                    className='h-[400px] max-h-[400px] min-h-[400px] resize-none overflow-y-auto border-0 bg-transparent font-mono text-xs'
                     placeholder='生成配置后显示在这里...'
                   />
                 </div>

--- a/miaomiaowu/src/routes/generator.tsx
+++ b/miaomiaowu/src/routes/generator.tsx
@@ -16,6 +16,7 @@ import { ButtonGroup } from '@/components/ui/button-group'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
+import { ClashConfigViewer } from '@/components/clash-config-viewer'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
   Dialog,
@@ -2983,7 +2984,7 @@ function SubscriptionGeneratorPage() {
                   <div>
                     <CardTitle>生成的 Clash 配置</CardTitle>
                     <CardDescription>
-                      预览生成的 YAML 配置文件
+                      大配置默认虚拟滚动预览，需要时可再编辑
                     </CardDescription>
                   </div>
                   <ButtonGroup mode='responsive' hideIconOnMobile>
@@ -3007,14 +3008,11 @@ function SubscriptionGeneratorPage() {
                 </div>
               </CardHeader>
               <CardContent>
-                <div className='rounded-lg border bg-muted/30'>
-                  <Textarea
-                    value={clashConfig}
-                    onChange={(e) => setClashConfig(e.target.value)}
-                    className='h-[400px] max-h-[400px] min-h-[400px] resize-none overflow-y-auto border-0 bg-transparent font-mono text-xs'
-                    placeholder='生成配置后显示在这里...'
-                  />
-                </div>
+                <ClashConfigViewer
+                  value={clashConfig}
+                  onChange={setClashConfig}
+                  height={400}
+                />
                 <div className='mt-4 flex justify-end gap-2'>
                   {(!isV3Mode || ruleMode === 'custom') && (
                     <>

--- a/miaomiaowu/src/routes/nodes.index.tsx
+++ b/miaomiaowu/src/routes/nodes.index.tsx
@@ -7,7 +7,7 @@ import { toast } from 'sonner'
 import { Topbar } from '@/components/layout/topbar'
 import { useAuthStore } from '@/stores/auth-store'
 import { api } from '@/lib/api'
-import { cn } from '@/lib/utils'
+import { cn, getPageNumbers } from '@/lib/utils'
 
 const CLASH_DRAFT_KEY_PREFIX = 'mmw_clash_config_draft_'
 import { Button } from '@/components/ui/button'
@@ -27,7 +27,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { type ProxyNode, type ClashProxy } from '@/lib/proxy-types'
 import { load as parseYAML, dump as dumpYAML } from 'js-yaml'
-import { Check, Pencil, X, Undo2, Activity, Eye, Copy, ChevronDown, Link2, Flag, GripVertical, Zap, Loader2, Expand, List, ArrowUpToLine, ArrowDownToLine, ArrowUp, ArrowDown, ArrowUpDown, Gauge } from 'lucide-react'
+import { Check, Pencil, X, Undo2, Activity, Eye, Copy, ChevronDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Link2, Flag, GripVertical, Zap, Loader2, Expand, List, ArrowUpToLine, ArrowDownToLine, ArrowUp, ArrowDown, ArrowUpDown, Gauge } from 'lucide-react'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import IpIcon from '@/assets/icons/ip.svg'
 import CaidanIcon from '@/assets/icons/125.svg'
@@ -380,6 +380,131 @@ const STORAGE_KEY_PROTOCOL = 'mmw_nodes_selectedProtocol'
 const STORAGE_KEY_TAG = 'mmw_nodes_tagFilter'
 const STORAGE_KEY_SELECTED_IDS = 'mmw_nodes_selectedIds'
 const STORAGE_KEY_RENDER_MODE = 'mmw_nodes_renderMode'
+const STORAGE_KEY_PAGE_SIZE = 'mmw_nodes_pageSize'
+const NODE_PAGE_SIZE_OPTIONS = [20, 50, 100, 200] as const
+
+function getStoredNodePageSize(): number {
+  try {
+    const raw = Number(localStorage.getItem(STORAGE_KEY_PAGE_SIZE))
+    if (NODE_PAGE_SIZE_OPTIONS.includes(raw as (typeof NODE_PAGE_SIZE_OPTIONS)[number])) {
+      return raw
+    }
+  } catch {
+    // ignore
+  }
+  return 50
+}
+
+// 节点列表分页条（顶部/底部复用）
+function NodeListPagination({
+  position,
+  total,
+  page,
+  pageSize,
+  totalPages,
+  onPageChange,
+  onPageSizeChange,
+}: {
+  position: 'top' | 'bottom'
+  total: number
+  page: number
+  pageSize: number
+  totalPages: number
+  onPageChange: (page: number) => void
+  onPageSizeChange: (size: number) => void
+}) {
+  if (total <= 0) return null
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between',
+        position === 'top' ? 'mb-4 border-b pb-4' : 'mt-4 border-t pt-4'
+      )}
+    >
+      <div className='flex flex-wrap items-center gap-2 text-sm text-muted-foreground'>
+        <span>每页</span>
+        <Select
+          value={String(pageSize)}
+          onValueChange={(v) => onPageSizeChange(Number(v))}
+        >
+          <SelectTrigger className='h-8 w-[96px]'>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {NODE_PAGE_SIZE_OPTIONS.map((size) => (
+              <SelectItem key={size} value={String(size)}>
+                {size}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <span>
+          共 {total} 个 · 第 {page}/{totalPages} 页
+        </span>
+      </div>
+      <div className='flex flex-wrap items-center gap-1'>
+        <Button
+          variant='outline'
+          size='icon'
+          className='h-8 w-8'
+          disabled={page <= 1}
+          onClick={() => onPageChange(1)}
+          title='第一页'
+        >
+          <ChevronsLeft className='h-4 w-4' />
+        </Button>
+        <Button
+          variant='outline'
+          size='icon'
+          className='h-8 w-8'
+          disabled={page <= 1}
+          onClick={() => onPageChange(Math.max(1, page - 1))}
+          title='上一页'
+        >
+          <ChevronLeft className='h-4 w-4' />
+        </Button>
+        {getPageNumbers(page, totalPages).map((item, idx) =>
+          item === '...' ? (
+            <span key={`ellipsis-${position}-${idx}`} className='px-1 text-muted-foreground'>
+              ...
+            </span>
+          ) : (
+            <Button
+              key={`${position}-${item}`}
+              variant={item === page ? 'default' : 'outline'}
+              size='sm'
+              className='h-8 min-w-8 px-2'
+              onClick={() => onPageChange(item as number)}
+            >
+              {item}
+            </Button>
+          )
+        )}
+        <Button
+          variant='outline'
+          size='icon'
+          className='h-8 w-8'
+          disabled={page >= totalPages}
+          onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+          title='下一页'
+        >
+          <ChevronRight className='h-4 w-4' />
+        </Button>
+        <Button
+          variant='outline'
+          size='icon'
+          className='h-8 w-8'
+          disabled={page >= totalPages}
+          onClick={() => onPageChange(totalPages)}
+          title='最后一页'
+        >
+          <ChevronsRight className='h-4 w-4' />
+        </Button>
+      </div>
+    </div>
+  )
+}
 
 // 从 localStorage 获取保存的筛选状态
 function getStoredFilterState() {
@@ -474,6 +599,10 @@ function NodesPage() {
   // 是否给导入节点强制写 skip-cert-verify（默认关，不污染节点原配置；不持久化）
   const [forceNodeSkipCert, setForceNodeSkipCert] = useState<boolean>(false)
 
+  // 订阅导入：定时自动更新
+  const [subscriptionAutoUpdate, setSubscriptionAutoUpdate] = useState(false)
+  const [subscriptionUpdateInterval, setSubscriptionUpdateInterval] = useState<number>(60)
+
   // 导入节点卡片折叠状态 - 默认折叠
   const [isInputCardExpanded, setIsInputCardExpanded] = useState(false)
 
@@ -483,6 +612,8 @@ function NodesPage() {
   // 虚拟滚动模式状态 - 从 localStorage 恢复，无缓存时先默认 virtual（后续根据节点数调整）
   const [renderMode, setRenderMode] = useState<RenderMode>(() => getStoredRenderMode() ?? 'virtual')
   const [renderModeInitialized, setRenderModeInitialized] = useState(() => getStoredRenderMode() !== null)
+  const [nodePage, setNodePage] = useState(1)
+  const [nodePageSize, setNodePageSize] = useState<number>(() => getStoredNodePageSize())
   const [sortMode, setSortMode] = useState(false)
   const nodeOrderSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const virtualListRef = useRef<HTMLDivElement>(null)
@@ -652,6 +783,13 @@ function NodesPage() {
       localStorage.setItem(STORAGE_KEY_RENDER_MODE, renderMode)
     } catch {}
   }, [renderMode])
+
+  // 保存每页条数到 localStorage
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY_PAGE_SIZE, String(nodePageSize))
+    } catch {}
+  }, [nodePageSize])
 
   useEffect(() => {
     try {
@@ -2005,7 +2143,14 @@ function NodesPage() {
 
   // 从订阅获取节点
   const fetchSubscriptionMutation = useMutation({
-    mutationFn: async ({ url, userAgent, fetchSkipCertVerify, forceNodeSkipCert }: { url: string; userAgent: string; fetchSkipCertVerify: boolean; forceNodeSkipCert: boolean }) => {
+    mutationFn: async ({ url, userAgent, fetchSkipCertVerify, forceNodeSkipCert }: {
+      url: string
+      userAgent: string
+      fetchSkipCertVerify: boolean
+      forceNodeSkipCert: boolean
+      autoUpdate: boolean
+      updateIntervalMinutes: number
+    }) => {
       const response = await api.post('/api/admin/nodes/fetch-subscription', {
         url,
         user_agent: userAgent,
@@ -2077,6 +2222,8 @@ function NodesPage() {
           name: finalTag,
           url: variables.url,
           user_agent: variables.userAgent, // 保存 User-Agent
+          auto_update: variables.autoUpdate,
+          update_interval_minutes: variables.updateIntervalMinutes,
         })
         // 刷新外部订阅列表和流量数据
         queryClient.invalidateQueries({ queryKey: ['external-subscriptions'] })
@@ -2387,6 +2534,8 @@ function NodesPage() {
       userAgent: finalUserAgent,
       fetchSkipCertVerify,
       forceNodeSkipCert,
+      autoUpdate: subscriptionAutoUpdate,
+      updateIntervalMinutes: subscriptionUpdateInterval,
     })
   }
 
@@ -2602,10 +2751,42 @@ function NodesPage() {
 
   const deferredFilteredNodes = useDeferredValue(filteredNodes)
 
+  // 筛选变化时回到第 1 页
+  useEffect(() => {
+    setNodePage(1)
+  }, [selectedProtocol, tagFilter, displayNodes.length])
+
+  const totalFilteredNodes = deferredFilteredNodes.length
+  const totalNodePages = Math.max(1, Math.ceil(totalFilteredNodes / nodePageSize) || 1)
+
+  useEffect(() => {
+    if (nodePage > totalNodePages) {
+      setNodePage(totalNodePages)
+    }
+  }, [nodePage, totalNodePages])
+
+  const paginatedNodes = useMemo(() => {
+    const start = (nodePage - 1) * nodePageSize
+    return deferredFilteredNodes.slice(start, start + nodePageSize)
+  }, [deferredFilteredNodes, nodePage, nodePageSize])
+
+  const pageRangeLabel = useMemo(() => {
+    if (totalFilteredNodes === 0) return '0'
+    const start = (nodePage - 1) * nodePageSize + 1
+    const end = Math.min(nodePage * nodePageSize, totalFilteredNodes)
+    return `${start}-${end}`
+  }, [nodePage, nodePageSize, totalFilteredNodes])
+
+  // 翻页时滚回列表顶部
+  useEffect(() => {
+    virtualListRef.current?.scrollTo?.({ top: 0 })
+    tableVirtualListRef.current?.scrollTo?.({ top: 0 })
+  }, [nodePage, nodePageSize])
+
   // 虚拟列表 - 移动端卡片视图
   const mobileVirtualEnabled = renderMode === 'virtual' && !isTablet
   const rowVirtualizer = useVirtualizer({
-    count: mobileVirtualEnabled ? deferredFilteredNodes.length : 0,
+    count: mobileVirtualEnabled ? paginatedNodes.length : 0,
     getScrollElement: () => virtualListRef.current,
     estimateSize: () => 180,
     overscan: 10,
@@ -2615,7 +2796,7 @@ function NodesPage() {
   // 虚拟列表 - 桌面端/平板端表格视图
   const tableVirtualEnabled = renderMode === 'virtual' && isTablet
   const tableVirtualizer = useVirtualizer({
-    count: tableVirtualEnabled ? deferredFilteredNodes.length : 0,
+    count: tableVirtualEnabled ? paginatedNodes.length : 0,
     getScrollElement: () => tableVirtualListRef.current,
     estimateSize: () => 56,
     overscan: 20,
@@ -2980,6 +3161,46 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                           为订阅导入的节点设置标签，留空将使用服务器地址作为标签
                         </p>
                       </div>
+                      <div className='space-y-2 rounded-md border p-3'>
+                        <div className='flex items-center justify-between gap-3'>
+                          <div className='space-y-1'>
+                            <Label htmlFor='subscription-auto-update' className='text-sm font-medium cursor-pointer'>
+                              定时更新此订阅
+                            </Label>
+                            <p className='text-xs text-muted-foreground'>
+                              开启后，服务端会按设定间隔自动拉取订阅并同步节点
+                            </p>
+                          </div>
+                          <Switch
+                            id='subscription-auto-update'
+                            checked={subscriptionAutoUpdate}
+                            onCheckedChange={setSubscriptionAutoUpdate}
+                          />
+                        </div>
+                        {subscriptionAutoUpdate && (
+                          <div className='flex flex-wrap items-center gap-2 pt-1'>
+                            <Label htmlFor='subscription-update-interval' className='text-sm whitespace-nowrap'>
+                              更新间隔
+                            </Label>
+                            <Select
+                              value={String(subscriptionUpdateInterval)}
+                              onValueChange={(v) => setSubscriptionUpdateInterval(Number(v))}
+                            >
+                              <SelectTrigger id='subscription-update-interval' className='w-[160px]'>
+                                <SelectValue placeholder='选择间隔' />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value='30'>30 分钟</SelectItem>
+                                <SelectItem value='60'>1 小时</SelectItem>
+                                <SelectItem value='180'>3 小时</SelectItem>
+                                <SelectItem value='360'>6 小时</SelectItem>
+                                <SelectItem value='720'>12 小时</SelectItem>
+                                <SelectItem value='1440'>24 小时</SelectItem>
+                              </SelectContent>
+                            </Select>
+                          </div>
+                        )}
+                      </div>
                       <div className='flex justify-end gap-2'>
                         <Button
                           onClick={handleFetchSubscription}
@@ -3007,7 +3228,14 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
               <CardHeader>
                 <div className='flex flex-col gap-4 md:flex-row md:items-center md:justify-between'>
                   <div>
-                    <CardTitle>节点列表 ({deferredFilteredNodes.length})</CardTitle>
+                    <CardTitle>
+                      节点列表 ({deferredFilteredNodes.length})
+                      {totalFilteredNodes > 0 && (
+                        <span className='ml-2 text-sm font-normal text-muted-foreground'>
+                          显示 {pageRangeLabel}
+                        </span>
+                      )}
+                    </CardTitle>
                     <p className='mt-2 text-sm font-semibold text-destructive'>注意!!! 节点的修改与删除均会同步更新所有订阅 </p>
                     <p className='mt-2 text-xs text-primary flex flex-wrap items-center gap-1'>
                       <Pencil className='h-4 w-4 inline' /> 编辑节点名称，
@@ -3354,6 +3582,19 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                     </div>
                   )}
 
+                  <NodeListPagination
+                    position='top'
+                    total={totalFilteredNodes}
+                    page={nodePage}
+                    pageSize={nodePageSize}
+                    totalPages={totalNodePages}
+                    onPageChange={setNodePage}
+                    onPageSizeChange={(size) => {
+                      setNodePageSize(size)
+                      setNodePage(1)
+                    }}
+                  />
+
                 {/* 移动端卡片视图 (<768px) */}
                 {!isTablet && renderMode === 'expanded' && (
                 <DndContext
@@ -3364,7 +3605,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                   onDragCancel={handleDragCancel}
                 >
                   <SortableContext
-                    items={deferredFilteredNodes.map(n => n.id)}
+                    items={paginatedNodes.map(n => n.id)}
                     strategy={verticalListSortingStrategy}
                   >
                     <div className='space-y-3'>
@@ -3375,7 +3616,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                           </CardContent>
                         </Card>
                       ) : (
-                        deferredFilteredNodes.map(node => (
+                        paginatedNodes.map(node => (
                           <SortableCard
                             key={node.id}
                             id={node.id}
@@ -3766,7 +4007,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                         }}
                       >
                         {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-                          const node = deferredFilteredNodes[virtualRow.index]
+                          const node = paginatedNodes[virtualRow.index]
                           if (!node) return null
                           return (
                             <div
@@ -4082,7 +4323,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                   {isTablet && !isDesktop && renderMode === 'expanded' && (
                   <div className='rounded-md border'>
                     <SortableContext
-                    items={deferredFilteredNodes.map(n => n.id)}
+                    items={paginatedNodes.map(n => n.id)}
                       strategy={verticalListSortingStrategy}
                     >
                     <Table className='w-full'>
@@ -4104,7 +4345,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                           </TableCell>
                         </TableRow>
                       ) : (
-                        deferredFilteredNodes.map(node => (
+                        paginatedNodes.map(node => (
                           <SortableTableRow
                             key={node.id}
                             id={node.id}
@@ -4573,7 +4814,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                             }}
                           >
                             {tableVirtualizer.getVirtualItems().map((virtualRow) => {
-                              const node = deferredFilteredNodes[virtualRow.index]
+                              const node = paginatedNodes[virtualRow.index]
                               if (!node) return null
                               return (
                                 <div
@@ -4804,7 +5045,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                   {isDesktop && renderMode === 'expanded' && (
                   <div className='rounded-md border'>
                     <SortableContext
-                      items={deferredFilteredNodes.map(n => n.id)}
+                      items={paginatedNodes.map(n => n.id)}
                       strategy={verticalListSortingStrategy}
                     >
                       <Table className='w-full'>
@@ -4827,7 +5068,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                               </TableCell>
                             </TableRow>
                           ) : (
-                            deferredFilteredNodes.map(node => (
+                            paginatedNodes.map(node => (
                           <SortableTableRow
                             key={node.id}
                             id={node.id}
@@ -5396,7 +5637,7 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                             }}
                           >
                             {tableVirtualizer.getVirtualItems().map((virtualRow) => {
-                              const node = deferredFilteredNodes[virtualRow.index]
+                              const node = paginatedNodes[virtualRow.index]
                               if (!node) return null
                               return (
                                 <div
@@ -5703,6 +5944,19 @@ vless://uuid@example.com:443?type=ws&security=tls&path=/websocket#VLESS节点
                     document.body
                   )}
                 </DndContext>
+
+                  <NodeListPagination
+                    position='bottom'
+                    total={totalFilteredNodes}
+                    page={nodePage}
+                    pageSize={nodePageSize}
+                    totalPages={totalNodePages}
+                    onPageChange={setNodePage}
+                    onPageSizeChange={(size) => {
+                      setNodePageSize(size)
+                      setNodePage(1)
+                    }}
+                  />
                 </div>
               </CardContent>
             </Card>

--- a/miaomiaowu/src/routes/subscribe-files.index.tsx
+++ b/miaomiaowu/src/routes/subscribe-files.index.tsx
@@ -95,6 +95,8 @@ type ExternalSubscription = {
   total: number
   expire: string | null
   traffic_mode: 'download' | 'upload' | 'both' | 'none'
+  auto_update: boolean
+  update_interval_minutes: number
   created_at: string
   updated_at: string
 }
@@ -381,7 +383,9 @@ function SubscribeFilesPage() {
     name: '',
     url: '',
     user_agent: '',
-    traffic_mode: 'both' as 'download' | 'upload' | 'both' | 'none'
+    traffic_mode: 'both' as 'download' | 'upload' | 'both' | 'none',
+    auto_update: false,
+    update_interval_minutes: 60,
   })
 
   // 代理集合对话框状态
@@ -763,12 +767,22 @@ function SubscribeFilesPage() {
 
   // 更新外部订阅
   const updateExternalSubMutation = useMutation({
-    mutationFn: async (data: { id: number; name: string; url: string; user_agent: string; traffic_mode: string }) => {
+    mutationFn: async (data: {
+      id: number
+      name: string
+      url: string
+      user_agent: string
+      traffic_mode: string
+      auto_update?: boolean
+      update_interval_minutes?: number
+    }) => {
       await api.put(`/api/user/external-subscriptions?id=${data.id}`, {
         name: data.name,
         url: data.url,
         user_agent: data.user_agent,
-        traffic_mode: data.traffic_mode
+        traffic_mode: data.traffic_mode,
+        auto_update: data.auto_update,
+        update_interval_minutes: data.update_interval_minutes,
       })
     },
     onSuccess: () => {
@@ -4024,7 +4038,18 @@ function SubscribeFilesPage() {
                   columns={[
                     {
                       header: '名称',
-                      cell: (sub) => sub.name,
+                      cell: (sub) => (
+                        <div className='flex flex-col gap-1'>
+                          <span>{sub.name}</span>
+                          {sub.auto_update && (
+                            <Badge variant='secondary' className='w-fit text-[10px]'>
+                              定时 {sub.update_interval_minutes >= 60
+                                ? `${Math.round(sub.update_interval_minutes / 60)}h`
+                                : `${sub.update_interval_minutes}m`}
+                            </Badge>
+                          )}
+                        </div>
+                      ),
                       cellClassName: 'font-medium'
                     },
                     {
@@ -4242,7 +4267,9 @@ function SubscribeFilesPage() {
                                 name: sub.name,
                                 url: sub.url,
                                 user_agent: sub.user_agent,
-                                traffic_mode: sub.traffic_mode || 'both'
+                                traffic_mode: sub.traffic_mode || 'both',
+                                auto_update: Boolean(sub.auto_update),
+                                update_interval_minutes: sub.update_interval_minutes > 0 ? sub.update_interval_minutes : 60,
                               })
                               setEditExternalSubDialogOpen(true)
                             }}
@@ -4316,6 +4343,13 @@ function SubscribeFilesPage() {
                             </TooltipContent>
                           </Tooltip>
                           <div className='font-medium text-sm truncate'>{sub.name}</div>
+                          {sub.auto_update && (
+                            <div className='text-[10px] text-muted-foreground'>
+                              定时更新 · {sub.update_interval_minutes >= 60
+                                ? `${Math.round(sub.update_interval_minutes / 60)} 小时`
+                                : `${sub.update_interval_minutes} 分钟`}
+                            </div>
+                          )}
                         </div>
                         <div className='flex items-center gap-1'>
                           <Button
@@ -4329,7 +4363,9 @@ function SubscribeFilesPage() {
                                 name: sub.name,
                                 url: sub.url,
                                 user_agent: sub.user_agent,
-                                traffic_mode: sub.traffic_mode || 'both'
+                                traffic_mode: sub.traffic_mode || 'both',
+                                auto_update: Boolean(sub.auto_update),
+                                update_interval_minutes: sub.update_interval_minutes > 0 ? sub.update_interval_minutes : 60,
                               })
                               setEditExternalSubDialogOpen(true)
                             }}
@@ -6385,6 +6421,46 @@ function SubscribeFilesPage() {
                 选择如何计算已用流量：上下行为两者相加，仅下行或仅上行则只计算对应流量
               </p>
             </div>
+            <div className='space-y-2 rounded-md border p-3'>
+              <div className='flex items-center justify-between gap-3'>
+                <div className='space-y-1'>
+                  <Label htmlFor='edit-sub-auto-update' className='text-sm font-medium cursor-pointer'>
+                    定时更新此订阅
+                  </Label>
+                  <p className='text-xs text-muted-foreground'>
+                    开启后服务端按间隔自动拉取并同步节点
+                  </p>
+                </div>
+                <Switch
+                  id='edit-sub-auto-update'
+                  checked={editExternalSubForm.auto_update}
+                  onCheckedChange={(checked) => setEditExternalSubForm(prev => ({ ...prev, auto_update: checked }))}
+                />
+              </div>
+              {editExternalSubForm.auto_update && (
+                <div className='flex flex-wrap items-center gap-2 pt-1'>
+                  <Label htmlFor='edit-sub-update-interval' className='text-sm whitespace-nowrap'>
+                    更新间隔
+                  </Label>
+                  <Select
+                    value={String(editExternalSubForm.update_interval_minutes)}
+                    onValueChange={(v) => setEditExternalSubForm(prev => ({ ...prev, update_interval_minutes: Number(v) }))}
+                  >
+                    <SelectTrigger id='edit-sub-update-interval' className='w-[160px]'>
+                      <SelectValue placeholder='选择间隔' />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value='30'>30 分钟</SelectItem>
+                      <SelectItem value='60'>1 小时</SelectItem>
+                      <SelectItem value='180'>3 小时</SelectItem>
+                      <SelectItem value='360'>6 小时</SelectItem>
+                      <SelectItem value='720'>12 小时</SelectItem>
+                      <SelectItem value='1440'>24 小时</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+            </div>
           </div>
           <DialogFooter>
             <Button variant='outline' onClick={() => setEditExternalSubDialogOpen(false)}>
@@ -6398,7 +6474,9 @@ function SubscribeFilesPage() {
                     name: editingExternalSub.name,
                     url: editExternalSubForm.url,
                     user_agent: editingExternalSub.user_agent,
-                    traffic_mode: editExternalSubForm.traffic_mode
+                    traffic_mode: editExternalSubForm.traffic_mode,
+                    auto_update: editExternalSubForm.auto_update,
+                    update_interval_minutes: editExternalSubForm.update_interval_minutes,
                   })
                   setEditExternalSubDialogOpen(false)
                   setEditingExternalSub(null)

--- a/miaomiaowu/src/routes/subscribe-files.index.tsx
+++ b/miaomiaowu/src/routes/subscribe-files.index.tsx
@@ -30,7 +30,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Calendar } from '@/components/ui/calendar'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
-import { Copy } from 'lucide-react'
+import { Copy, Layers} from 'lucide-react'
 import { Upload, Download, Edit, Settings, FileText, Save, Trash2, RefreshCw, ChevronDown, ChevronUp, ExternalLink, Eye, Calendar as CalendarIcon, Plus, Check, Ban, Info, Clock } from 'lucide-react'
 import { EditNodesDialog } from '@/components/edit-nodes-dialog'
 import { MobileEditNodesDialog } from '@/components/mobile-edit-nodes-dialog'
@@ -299,6 +299,14 @@ function SubscribeFilesPage() {
   // 对话框状态
   const [importDialogOpen, setImportDialogOpen] = useState(false)
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false)
+  const [aggregateDialogOpen, setAggregateDialogOpen] = useState(false)
+  const [aggregateForm, setAggregateForm] = useState({
+    name: '',
+    description: '',
+    filename: '',
+    selected_tags: [] as string[],
+    template_filename: '',
+  })
   const [editDialogOpen, setEditDialogOpen] = useState(false)
   const [editingFile, setEditingFile] = useState<SubscribeFile | null>(null)
   const [editMetadataDialogOpen, setEditMetadataDialogOpen] = useState(false)
@@ -704,6 +712,29 @@ function SubscribeFilesPage() {
     },
     onError: (error: any) => {
       toast.error(error.response?.data?.error || '删除失败')
+    },
+  })
+
+  // 创建聚合订阅
+  const createAggregateMutation = useMutation({
+    mutationFn: async (payload: {
+      name: string
+      description?: string
+      filename?: string
+      selected_tags: string[]
+      template_filename?: string
+    }) => {
+      const response = await api.post('/api/admin/subscribe-files/create-aggregate', payload)
+      return response.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['subscribe-files'] })
+      setAggregateDialogOpen(false)
+      setAggregateForm({ name: '', description: '', filename: '', selected_tags: [], template_filename: '' })
+      toast.success('聚合订阅已创建，将随源订阅节点自动更新')
+    },
+    onError: (error: any) => {
+      toast.error(error.response?.data?.error || '创建聚合订阅失败')
     },
   })
 
@@ -1598,7 +1629,26 @@ function SubscribeFilesPage() {
     importMutation.mutate(importForm)
   }
 
-  const handleUpload = () => {
+  
+  const handleCreateAggregate = () => {
+    if (!aggregateForm.name.trim()) {
+      toast.error('请输入订阅名称')
+      return
+    }
+    if (aggregateForm.selected_tags.length === 0) {
+      toast.error('请至少选择一个源订阅/标签')
+      return
+    }
+    createAggregateMutation.mutate({
+      name: aggregateForm.name.trim(),
+      description: aggregateForm.description.trim() || undefined,
+      filename: aggregateForm.filename.trim() || undefined,
+      selected_tags: aggregateForm.selected_tags,
+      template_filename: aggregateForm.template_filename || undefined,
+    })
+  }
+
+const handleUpload = () => {
     if (!uploadFile) {
       toast.error('请选择文件')
       return
@@ -2686,6 +2736,140 @@ function SubscribeFilesPage() {
                       </Button>
                       <Button onClick={handleUpload} disabled={uploadMutation.isPending}>
                         {uploadMutation.isPending ? '上传中...' : (uploadForm.overwrite_id > 0 ? '覆盖上传' : '上传')}
+                      </Button>
+                    </DialogFooter>
+                  </DialogContent>
+                </Dialog>
+                {/* 聚合订阅 */}
+                <Dialog open={aggregateDialogOpen} onOpenChange={(open) => {
+                  setAggregateDialogOpen(open)
+                  if (!open) {
+                    setAggregateForm({ name: '', description: '', filename: '', selected_tags: [], template_filename: '' })
+                  }
+                }}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DialogTrigger asChild>
+                        <Button variant='outline' size='sm'>
+                          <Layers className='h-4 w-4' />
+                        </Button>
+                      </DialogTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>聚合订阅</TooltipContent>
+                  </Tooltip>
+                  <DialogContent className='sm:max-w-lg max-h-[90vh] flex flex-col'>
+                    <DialogHeader>
+                      <DialogTitle>聚合订阅</DialogTitle>
+                      <DialogDescription>
+                        选择多个外部订阅（按标签），生成一个会随源订阅节点自动更新的新订阅。
+                        源订阅节点从 100 变为 20 时，聚合订阅也会同步变为 20。
+                      </DialogDescription>
+                    </DialogHeader>
+                    <div className='space-y-4 py-2 overflow-y-auto flex-1 min-h-0'>
+                      <div className='space-y-2'>
+                        <Label htmlFor='aggregate-name'>订阅名称 *</Label>
+                        <Input
+                          id='aggregate-name'
+                          value={aggregateForm.name}
+                          onChange={(e) => setAggregateForm({ ...aggregateForm, name: e.target.value })}
+                          placeholder='例如：聚合机场'
+                        />
+                      </div>
+                      <div className='space-y-2'>
+                        <Label htmlFor='aggregate-desc'>说明（可选）</Label>
+                        <Textarea
+                          id='aggregate-desc'
+                          value={aggregateForm.description}
+                          onChange={(e) => setAggregateForm({ ...aggregateForm, description: e.target.value })}
+                          placeholder='留空将自动生成说明'
+                          rows={2}
+                        />
+                      </div>
+                      <div className='space-y-2'>
+                        <Label htmlFor='aggregate-filename'>文件名（可选）</Label>
+                        <Input
+                          id='aggregate-filename'
+                          value={aggregateForm.filename}
+                          onChange={(e) => setAggregateForm({ ...aggregateForm, filename: e.target.value })}
+                          placeholder='留空则使用订阅名称'
+                        />
+                      </div>
+                      <div className='space-y-2'>
+                        <Label>源订阅 / 标签 *</Label>
+                        <p className='text-xs text-muted-foreground'>
+                          外部订阅同步后会以订阅名作为节点标签。也可选择其它节点标签。
+                        </p>
+                        <div className='flex flex-wrap gap-2 max-h-[220px] overflow-y-auto border rounded-md p-3'>
+                          {(() => {
+                            const externalNames = externalSubs.map((s: any) => s.name).filter(Boolean)
+                            const tagSet = new Set<string>([...externalNames, ...allNodeTags])
+                            const options = Array.from(tagSet).sort((a, b) => a.localeCompare(b, 'zh-CN'))
+                            if (options.length === 0) {
+                              return <span className='text-sm text-muted-foreground'>暂无可用标签，请先导入外部订阅或为节点打标签</span>
+                            }
+                            return options.map((tag) => {
+                              const selected = aggregateForm.selected_tags.includes(tag)
+                              const isExternal = externalNames.includes(tag)
+                              return (
+                                <Button
+                                  key={tag}
+                                  type='button'
+                                  size='sm'
+                                  variant={selected ? 'default' : 'outline'}
+                                  onClick={() => {
+                                    const next = selected
+                                      ? aggregateForm.selected_tags.filter((t) => t !== tag)
+                                      : [...aggregateForm.selected_tags, tag]
+                                    setAggregateForm({ ...aggregateForm, selected_tags: next })
+                                  }}
+                                >
+                                  {tag}
+                                </Button>
+                              )
+                            })
+                          })()}
+                        </div>
+                        {aggregateForm.selected_tags.length > 0 && (
+                          <p className='text-xs text-muted-foreground'>
+                            已选 {aggregateForm.selected_tags.length} 个：{aggregateForm.selected_tags.join('、')}
+                          </p>
+                        )}
+                      </div>
+                      <div className='space-y-2'>
+                        <Label>绑定 V3 模板（可选）</Label>
+                        <Select
+                          value={aggregateForm.template_filename || '__none__'}
+                          onValueChange={(v) => setAggregateForm({
+                            ...aggregateForm,
+                            template_filename: v === '__none__' ? '' : v,
+                          })}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder='不绑定模板' />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value='__none__'>不绑定模板（精简配置，实时节点）</SelectItem>
+                            {v3Templates.map((template: any) => (
+                              <SelectItem key={template.filename} value={template.filename}>
+                                {template.name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <p className='text-xs text-muted-foreground'>
+                          绑定模板后，获取订阅时会按模板 + 所选标签动态生成；不绑定则输出精简 Clash 配置，节点同样实时更新。
+                        </p>
+                      </div>
+                    </div>
+                    <DialogFooter className='shrink-0'>
+                      <Button variant='outline' onClick={() => setAggregateDialogOpen(false)}>
+                        取消
+                      </Button>
+                      <Button
+                        onClick={handleCreateAggregate}
+                        disabled={createAggregateMutation.isPending}
+                      >
+                        {createAggregateMutation.isPending ? '创建中...' : '创建聚合订阅'}
                       </Button>
                     </DialogFooter>
                   </DialogContent>


### PR DESCRIPTION
﻿## Summary
- External subscription scheduled auto-update (import/edit + backend scheduler)
- Nodes page dual top/bottom pagination
- Generator page node list pagination + virtualized Clash config preview (large YAML no longer freezes UI)
- Aggregate multiple source tags/subscriptions into one live-updating subscription
- GHCR Docker build workflow for fork releases

## Details
### Auto-update
- `auto_update` + `update_interval_minutes` on external subscriptions
- Scheduler syncs due external subscriptions

### Pagination
- `/nodes` and `/generator` node lists support page size + top/bottom controls

### Generator performance
- Clash config uses virtual-scroll preview by default
- Edit mode is local-buffered; copy/download available

### Aggregate subscription
- Subscribe-files: create aggregate from multiple tags (usually external sub names)
- Serves live nodes from DB by tags (tracks source grow/shrink)
- External sync cleans orphaned nodes when `syncScope=all` and refreshes template-bound subs

### CI
- `.github/workflows/docker-ghcr.yml` builds and pushes to `ghcr.io/remmai/miaomiaowu`

## Test plan
- [ ] Import external sub with auto-update; verify interval saved and scheduler runs
- [ ] `/nodes` top/bottom pagination + page size persistence
- [ ] `/generator` node list pagination; large config scrolls smoothly in preview mode
- [ ] Create aggregate subscription from 2+ tags; update source nodes and re-fetch aggregate
- [ ] Fork Actions: Docker GHCR workflow succeeds and image is pullable
